### PR TITLE
fix: stale cache behavior across storage backends

### DIFF
--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -329,5 +329,10 @@ export function useInvalidateGame(gameId: string | undefined) {
     qc.invalidateQueries({ queryKey: queryKeys.layouts(gameId) })
     qc.invalidateQueries({ queryKey: queryKeys.fonts(gameId) })
     qc.invalidateQueries({ queryKey: queryKeys.images(gameId) })
+    // Prefix-match the per-id queries; these include the layout query, which
+    // has staleTime: Infinity and is otherwise never refetched.
+    qc.invalidateQueries({ queryKey: ['collection', gameId] })
+    qc.invalidateQueries({ queryKey: ['layout', gameId] })
+    qc.invalidateQueries({ queryKey: ['cards', gameId] })
   }
 }

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -820,7 +820,7 @@ export default function GameEditorPage() {
     return false
   }, [gameId, collectionId, cards, selectedCard, savedCardJson])
 
-  const reloadCardsFromStorage = () => {
+  const reloadCardsFromStorage = async () => {
     if (!gameId || !collectionId) return
     // Remove all localStorage drafts for this collection so re-seeding uses clean storage data.
     for (const card of cards) {
@@ -831,8 +831,12 @@ export default function GameEditorPage() {
     setSavedCardJson('')
     // Allow the next query result to re-seed the cards state.
     cardsInitialized.current = false
-    // Force a fresh fetch from the storage backend.
-    queryClient.invalidateQueries({ queryKey: queryKeys.cards(gameId, collectionId) })
+    // Drop backend-internal caches (e.g. Google Drive keeps 5-min listing and
+    // content caches that would otherwise serve the refetch below stale data).
+    try { await storage?.clearCache?.() } catch (err) { console.error('Failed to clear storage cache:', err) }
+    // Force a fresh fetch of everything for this game — cards, collection,
+    // layout (staleTime: Infinity), fonts and images — from the backend.
+    invalidateGame()
     setShowReloadDialog(false)
   }
 

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -3,7 +3,7 @@ const DRIVE_API = "https://www.googleapis.com/drive/v3";
 const DRIVE_UPLOAD = "https://www.googleapis.com/upload/drive/v3";
 
 import { normalizeCard, normalizeLayout } from "../normalizeExport.js";
-import { putAsset, deleteAsset, listAssets } from "./assetCache.js";
+import { getAsset, putAsset, deleteAsset } from "./assetCache.js";
 
 const loadGoogleScript = () =>
   new Promise((resolve, reject) => {
@@ -202,6 +202,9 @@ export const createGoogleDriveStorage = (options = {}) => {
   const rmFile = async (fid) => {
     await drv(`${DRIVE_API}/files/${fid}`, { method: "DELETE" });
     invalidateCache(fid);
+    // Folder listings still reference the deleted file; a later list would
+    // re-read it and fail (or resurrect the item) for up to CACHE_TTL.
+    listingCache.clear();
   };
 
   const mkBinaryFile = async (name, mimeType, data, parentId, props = {}) => {
@@ -551,14 +554,84 @@ export const createGoogleDriveStorage = (options = {}) => {
 
   // --- Images ---
 
+  // Binary (non-JSON) files in a folder, cached like the JSON listings.
+  const binaryFilesInFolder = async (fid) => {
+    const key = `binaries:${fid}`;
+    const cached = getCachedListing(key);
+    if (cached) return cached;
+    const q = `'${escQ(fid)}' in parents and trashed=false and mimeType != 'application/json' and mimeType != 'application/vnd.google-apps.folder'`;
+    const files = (await drvJson(`${DRIVE_API}/files?q=${encodeURIComponent(q)}&fields=files(id,name,mimeType,appProperties)`)).files ?? [];
+    setCachedListing(key, files);
+    return files;
+  };
+
+  /** Download a Drive binary into the asset cache so the SW/useAssetUrl can serve it. */
+  const ensureCachedBinary = async (fid, assetPath, fallbackMime) => {
+    try {
+      if (await getAsset(assetPath)) return;
+      const r = await drv(`${DRIVE_API}/files/${fid}?alt=media`);
+      const blob = await r.blob();
+      const mime = blob.type || fallbackMime;
+      await putAsset(assetPath, blob, mime);
+    } catch { /* download failed — will retry next time */ }
+  };
+
+  const findImageFile = async (gameId, file) => {
+    const imgFolder = await imagesFolder(gameId);
+    const files = await binaryFilesInFolder(imgFolder);
+    return { folderId: imgFolder, entry: files.find(f => f.name === file) ?? null };
+  };
+
   const uploadImage = async (gameId, file) => {
     const imgFolder = await imagesFolder(gameId);
     const mimeType = file.type || "application/octet-stream";
     const arrayBuf = await file.arrayBuffer();
-    await mkBinaryFile(file.name, mimeType, arrayBuf, imgFolder, { type: "image", gameId });
+    const displayName = file.name.includes(".") ? file.name.slice(0, file.name.lastIndexOf(".")) : file.name;
+    await mkBinaryFile(file.name, mimeType, arrayBuf, imgFolder, { type: "image", gameId, displayName });
+    listingCache.delete(`binaries:${imgFolder}`);
     const urlPath = `/api/games/${gameId}/images/${file.name}`;
     await putAsset(urlPath, new Blob([arrayBuf], { type: mimeType }), mimeType);
     return urlPath;
+  };
+
+  const listImages = async (gameId) => {
+    const imgFolder = await imagesFolder(gameId);
+    const files = await binaryFilesInFolder(imgFolder);
+    const results = files.map(f => ({
+      file: f.name,
+      url: `/api/games/${gameId}/images/${f.name}`,
+      name: f.appProperties?.displayName || f.name.replace(/\.[^.]+$/, ""),
+    }));
+    // Prefetch binaries into the asset cache in the background.
+    for (const f of files) {
+      ensureCachedBinary(f.id, `/api/games/${gameId}/images/${f.name}`, "image/png");
+    }
+    return results;
+  };
+
+  const deleteImage = async (gameId, file) => {
+    const { entry } = await findImageFile(gameId, file);
+    if (entry) await rmFile(entry.id);
+    await deleteAsset(`/api/games/${gameId}/images/${file}`);
+  };
+
+  const renameImage = async (gameId, file, newName) => {
+    const { folderId, entry } = await findImageFile(gameId, file);
+    if (!entry) throw new Error("Image not found.");
+    await drv(`${DRIVE_API}/files/${entry.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json; charset=UTF-8" },
+      body: JSON.stringify({ appProperties: { displayName: newName } }),
+    });
+    listingCache.delete(`binaries:${folderId}`);
+  };
+
+  /** Drop all internal caches so the next read hits Drive (used by "reload from storage"). */
+  const clearCache = () => {
+    contentCache.clear();
+    listingCache.clear();
+    fileIds.clear();
+    folderIds.clear();
   };
 
   return {
@@ -568,6 +641,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     listCollections, getCollection, createCollection, updateCollection, deleteCollection,
     listCards, getCard, saveCard, deleteCard, copyCard,
     listFonts, addGoogleFont, uploadFont, deleteFont,
-    uploadImage,
+    uploadImage, listImages, deleteImage, renameImage,
+    clearCache,
   };
 };

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -195,6 +195,8 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
     isAuthorized() { return true; },
     async signIn() {},
     async signOut() {},
+    // No internal caches — every read hits IndexedDB.
+    clearCache() {},
 
     // ── Games ──────────────────────────────────────────────────────────────
 

--- a/src/storage/localFile.js
+++ b/src/storage/localFile.js
@@ -12,6 +12,8 @@ export const createLocalFileStorage = ({ defaultLayout }) => {
     isAuthorized() { return true; },
     async signIn() {},
     async signOut() {},
+    // No internal caches — every read hits the server.
+    clearCache() {},
 
     // Games
     async listGames() {

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -224,6 +224,8 @@ export const createS3Storage = (options = {}) => {
     },
     async signIn() {},
     async signOut() {},
+    // No internal caches — every read hits S3.
+    clearCache() {},
 
     // ── Games ──────────────────────────────────────────────────────────────
 

--- a/test/storageCaching.test.js
+++ b/test/storageCaching.test.js
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import "fake-indexeddb/auto";
+
+// Regression tests for save/cache behavior of the LIVE storage backends
+// (src/storage/*, used by the app — not the legacy src/web copies):
+//  - Google Drive listing caches must be invalidated on deletes, otherwise
+//    deleted cards/layouts/collections resurface (or break list queries) for
+//    up to 5 minutes.
+//  - Google Drive must implement the image API like the other backends.
+//  - Every backend must expose clearCache() so "reload from storage" can
+//    bypass backend-internal caches.
+
+// ── In-memory Google Drive mock ────────────────────────────────────────────
+
+const createDriveMock = () => {
+  const mockLocalStorage = new Map();
+  global.localStorage = {
+    getItem: (key) => mockLocalStorage.get(key) ?? null,
+    setItem: (key, value) => mockLocalStorage.set(key, String(value)),
+    removeItem: (key) => mockLocalStorage.delete(key),
+  };
+
+  global.document = {
+    createElement: () => ({ src: "", async: false, defer: false, onload: null, onerror: null }),
+    head: { appendChild: (script) => { if (script.onload) setTimeout(script.onload, 0); } },
+  };
+
+  const mockTokenClient = {
+    callback: null,
+    requestAccessToken: () => {
+      if (mockTokenClient.callback) {
+        setTimeout(() => {
+          mockTokenClient.callback({ access_token: "mock_access_token", expires_in: 3600 });
+        }, 0);
+      }
+    },
+  };
+
+  global.window = {
+    google: {
+      accounts: {
+        oauth2: {
+          initTokenClient: ({ callback }) => {
+            mockTokenClient.callback = callback;
+            return mockTokenClient;
+          },
+          revoke: (_token, callback) => { if (callback) callback(); },
+        },
+      },
+    },
+    location: { hostname: "example.com" },
+  };
+
+  // The fake Drive: id → { id, name, mimeType, appProperties, parents, content|binary }
+  const files = new Map();
+  let seq = 0;
+  const nid = (prefix) => `${prefix}_${++seq}`;
+
+  const parseQuery = (q) => {
+    const parent = q.match(/'([^']+)' in parents/)?.[1];
+    const mimeEq = q.match(/mimeType='([^']+)'/)?.[1];
+    const mimeNe = [...q.matchAll(/mimeType != '([^']+)'/g)].map((m) => m[1]);
+    return { parent, mimeEq, mimeNe };
+  };
+
+  const listFiles = (q) => {
+    const { parent, mimeEq, mimeNe } = parseQuery(q);
+    return [...files.values()].filter((f) => {
+      if (parent && !(f.parents ?? []).includes(parent)) return false;
+      if (mimeEq && f.mimeType !== mimeEq) return false;
+      if (mimeNe.includes(f.mimeType)) return false;
+      return true;
+    });
+  };
+
+  const fileSummary = (f) => ({
+    id: f.id, name: f.name, mimeType: f.mimeType, appProperties: f.appProperties,
+  });
+
+  const parseMultipart = async (body, contentType) => {
+    const boundary = contentType.match(/boundary=(.+)$/)?.[1];
+    const text = typeof body === "string" ? body : await body.text();
+    const parts = text
+      .split(`--${boundary}`)
+      .map((p) => p.replace(/^\r\n/, "").replace(/\r\n$/, ""))
+      .filter((p) => p && p !== "--");
+    const parsed = parts.map((part) => {
+      const sep = part.indexOf("\r\n\r\n");
+      const headers = part.slice(0, sep);
+      const payload = part.slice(sep + 4);
+      const mime = headers.match(/Content-Type:\s*([^;\r\n]+)/i)?.[1] ?? "application/octet-stream";
+      return { mime, payload };
+    });
+    const meta = JSON.parse(parsed[0].payload);
+    return { meta, content: parsed[1] };
+  };
+
+  global.fetch = async (url, options = {}) => {
+    const method = options.method ?? "GET";
+    const notFound = { ok: false, status: 404, text: async () => "Not found" };
+
+    // Create folder (or metadata-only file)
+    if (url.includes("/drive/v3/files?fields=id") && method === "POST") {
+      const meta = JSON.parse(options.body);
+      const id = nid("folder");
+      files.set(id, { id, ...meta, parents: meta.parents ?? [] });
+      return { ok: true, json: async () => ({ id }) };
+    }
+
+    // List files
+    if (url.includes("/drive/v3/files?q=")) {
+      const q = decodeURIComponent(url.split("q=")[1].split("&")[0]);
+      return { ok: true, json: async () => ({ files: listFiles(q).map(fileSummary) }) };
+    }
+
+    // Read content
+    if (url.includes("alt=media") && method === "GET") {
+      const id = url.split("/files/")[1].split("?")[0];
+      const f = files.get(id);
+      if (!f) return notFound;
+      return {
+        ok: true,
+        json: async () => f.content,
+        blob: async () => new Blob([f.binary ?? ""], { type: f.mimeType }),
+      };
+    }
+
+    // Update content
+    if (url.includes("uploadType=media") && method === "PATCH") {
+      const id = url.split("/files/")[1].split("?")[0];
+      const f = files.get(id);
+      if (!f) return notFound;
+      f.content = JSON.parse(options.body);
+      return { ok: true, json: async () => ({}) };
+    }
+
+    // Update metadata (e.g. renameImage patches appProperties)
+    if (url.match(/\/drive\/v3\/files\/[^/?]+$/) && method === "PATCH") {
+      const id = url.split("/files/")[1];
+      const f = files.get(id);
+      if (!f) return notFound;
+      const meta = JSON.parse(options.body);
+      Object.assign(f, { ...meta, appProperties: { ...f.appProperties, ...meta.appProperties } });
+      return { ok: true, json: async () => ({ id }) };
+    }
+
+    // Delete
+    if (method === "DELETE") {
+      const id = url.split("/files/")[1].split("?")[0];
+      files.delete(id);
+      return { ok: true, text: async () => "" };
+    }
+
+    // Multipart create (JSON or binary file)
+    if (url.includes("uploadType=multipart") && method === "POST") {
+      const contentType = options.headers?.["Content-Type"] ?? "";
+      const { meta, content } = await parseMultipart(options.body, contentType);
+      const id = nid("file");
+      const record = { id, ...meta, parents: meta.parents ?? [] };
+      if (content.mime === "application/json") record.content = JSON.parse(content.payload);
+      else record.binary = content.payload;
+      files.set(id, record);
+      return { ok: true, json: async () => ({ id }) };
+    }
+
+    return notFound;
+  };
+
+  return { files };
+};
+
+const defaultLayout = () => ({
+  version: 2,
+  id: "default",
+  name: "Default",
+  width: 63.5,
+  height: 88.9,
+  radius: 2.5,
+  bleed: 1.5,
+  root: { id: "root", name: "Root", layout: "stack", sizePct: 100, gap: 0, children: [], items: [] },
+});
+
+const makeStorage = async () => {
+  const { createGoogleDriveStorage } = await import("../src/storage/googleDrive.js");
+  const storage = createGoogleDriveStorage({
+    clientId: "test-client-id.apps.googleusercontent.com",
+    appTag: "test-app",
+    defaultLayout,
+  });
+  await storage.init();
+  await storage.signIn();
+  return storage;
+};
+
+// ── Listing-cache invalidation on delete ───────────────────────────────────
+
+test("googleDrive: deleted card disappears from listCards immediately", async () => {
+  createDriveMock();
+  const storage = await makeStorage();
+  const game = await storage.createGame("Cache Game");
+
+  await storage.saveCard(game.id, "default", "card-a", { id: "card-a", name: "A", fields: {} });
+  await storage.saveCard(game.id, "default", "card-b", { id: "card-b", name: "B", fields: {} });
+  let cards = await storage.listCards(game.id, "default");
+  assert.deepEqual(cards.map((c) => c.id).sort(), ["card-a", "card-b"]);
+
+  await storage.deleteCard(game.id, "default", "card-a");
+  // Without listing-cache invalidation this either throws (stale listing
+  // points at a deleted file) or resurrects card-a for up to 5 minutes.
+  cards = await storage.listCards(game.id, "default");
+  assert.deepEqual(cards.map((c) => c.id), ["card-b"]);
+});
+
+test("googleDrive: deleted layout disappears from listLayouts immediately", async () => {
+  createDriveMock();
+  const storage = await makeStorage();
+  const game = await storage.createGame("Cache Game");
+
+  await storage.createLayout(game.id, "Extra Layout");
+  let layouts = await storage.listLayouts(game.id);
+  assert.equal(layouts.length, 2);
+
+  await storage.deleteLayout(game.id, "extra-layout");
+  layouts = await storage.listLayouts(game.id);
+  assert.deepEqual(layouts.map((l) => l.id), ["default"]);
+});
+
+test("googleDrive: deleted collection disappears from listCollections immediately", async () => {
+  createDriveMock();
+  const storage = await makeStorage();
+  const game = await storage.createGame("Cache Game");
+
+  await storage.createCollection(game.id, "Extras", "default");
+  let cols = await storage.listCollections(game.id);
+  assert.deepEqual(cols.map((c) => c.id).sort(), ["default", "extras"]);
+
+  await storage.deleteCollection(game.id, "extras");
+  cols = await storage.listCollections(game.id);
+  assert.deepEqual(cols.map((c) => c.id), ["default"]);
+});
+
+// ── Image API parity with the other backends ───────────────────────────────
+
+const fakeFile = (name, type, data) => ({
+  name,
+  type,
+  arrayBuffer: async () => new TextEncoder().encode(data).buffer,
+});
+
+test("googleDrive: image upload/list/rename/delete round-trip", async () => {
+  createDriveMock();
+  const storage = await makeStorage();
+  const game = await storage.createGame("Image Game");
+
+  const url = await storage.uploadImage(game.id, fakeFile("hero.png", "image/png", "PNGDATA"));
+  assert.equal(url, `/api/games/${game.id}/images/hero.png`);
+
+  let images = await storage.listImages(game.id);
+  assert.equal(images.length, 1);
+  assert.equal(images[0].file, "hero.png");
+  assert.equal(images[0].url, url);
+  assert.equal(images[0].name, "hero");
+
+  await storage.renameImage(game.id, "hero.png", "Hero Art");
+  images = await storage.listImages(game.id);
+  assert.equal(images[0].name, "Hero Art");
+  assert.equal(images[0].url, url, "rename must not change the asset URL");
+
+  await storage.deleteImage(game.id, "hero.png");
+  images = await storage.listImages(game.id);
+  assert.deepEqual(images, []);
+});
+
+// ── clearCache: the "reload from storage" path ─────────────────────────────
+
+test("googleDrive: clearCache drops stale listings so reload sees remote changes", async () => {
+  createDriveMock();
+  const deviceA = await makeStorage();
+  const deviceB = await makeStorage();
+
+  const game = await deviceA.createGame("Sync Game");
+  await deviceA.saveCard(game.id, "default", "card-a", { id: "card-a", name: "A", fields: {} });
+  assert.equal((await deviceA.listCards(game.id, "default")).length, 1);
+
+  // Another device adds a card; A's 5-minute listing cache hides it.
+  await deviceB.saveCard(game.id, "default", "card-b", { id: "card-b", name: "B", fields: {} });
+  assert.equal((await deviceA.listCards(game.id, "default")).length, 1,
+    "listing cache still serves the old listing (documents the 5-min TTL)");
+
+  deviceA.clearCache();
+  assert.equal((await deviceA.listCards(game.id, "default")).length, 2,
+    "after clearCache the reload must see the remote change");
+});
+
+test("googleDrive: clearCache drops stale content so reload sees remote edits", async () => {
+  createDriveMock();
+  const deviceA = await makeStorage();
+  const deviceB = await makeStorage();
+
+  const game = await deviceA.createGame("Sync Game");
+  await deviceA.saveCard(game.id, "default", "c1", { id: "c1", name: "Old", fields: {} });
+  assert.equal((await deviceA.getCard(game.id, "default", "c1")).name, "Old");
+
+  await deviceB.listCards(game.id, "default"); // warm B's file-id cache
+  await deviceB.saveCard(game.id, "default", "c1", { id: "c1", name: "New", fields: {} });
+  assert.equal((await deviceA.getCard(game.id, "default", "c1")).name, "Old",
+    "content cache still serves the old card (documents the 5-min TTL)");
+
+  deviceA.clearCache();
+  assert.equal((await deviceA.getCard(game.id, "default", "c1")).name, "New");
+});
+
+// ── clearCache exists on every backend ─────────────────────────────────────
+
+test("all backends expose clearCache for reload-from-storage", async () => {
+  createDriveMock();
+  const { createGoogleDriveStorage } = await import("../src/storage/googleDrive.js");
+  const { createLocalFileStorage } = await import("../src/storage/localFile.js");
+  const { createIndexedDBStorage } = await import("../src/storage/indexedDB.js");
+  const { createS3Storage } = await import("../src/storage/s3.js");
+
+  const backends = {
+    googleDrive: createGoogleDriveStorage({ clientId: "x.y", defaultLayout }),
+    localFile: createLocalFileStorage({ defaultLayout }),
+    indexedDB: createIndexedDBStorage({ defaultLayout }),
+    s3: createS3Storage({ defaultLayout, bucket: "b", accessKeyId: "k", secretAccessKey: "s" }),
+  };
+  for (const [name, backend] of Object.entries(backends)) {
+    assert.equal(typeof backend.clearCache, "function", `${name} must expose clearCache()`);
+  }
+});


### PR DESCRIPTION
Google Drive backend:
- Invalidate folder-listing caches on every file delete. Deleting a card/layout/collection left the 5-minute listing cache pointing at the removed file, so the next list either failed (404 on a stale file id) or resurrected the deleted item until the TTL expired.
- Implement listImages/deleteImage/renameImage for parity with the other backends. Images uploaded to Drive never appeared in the images tab, and deleting one crashed (method undefined). Display names live in appProperties so renaming never changes the asset URL.
- Add clearCache() dropping content, listing and id caches.

All backends now expose clearCache() (no-op where stateless) so the "reload from storage" button can bypass backend-internal caches.

Reload from storage now reloads everything:
- useInvalidateGame also invalidates the cards, per-collection and per-layout queries. The layout query uses staleTime: Infinity, so it was previously never refreshed — layout changes made on another device/browser were invisible until a full page reload, and the reload button only refetched cards.
- The reload handler clears backend caches before invalidating, so on Google Drive the refetch reaches Drive instead of the 5-min caches.

Regression tests in test/storageCaching.test.js run against the live src/storage backends (the older Drive tests cover the legacy src/web copies) and fail without these fixes.