### PR TITLE
Rename items directly from every list

### DIFF
--- a/src/components/FilterableList.tsx
+++ b/src/components/FilterableList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
-import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight, TextCursorInput } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import useFuzzyFilter from '@/hooks/useFuzzyFilter'
@@ -18,6 +18,7 @@ type FilterableListProps<T> = {
   getGroup?: (item: T) => string | undefined
   selectedKey?: string | null
   onSelect?: (key: string | null) => void
+  onRename?: (key: string, newName: string) => void | Promise<void>
   selectedKeys?: Set<string>
   onSelectedKeysChange?: (keys: Set<string>) => void
   renderItem: (item: T, viewMode: ViewMode, selected: boolean, index: number) => ReactNode
@@ -33,7 +34,7 @@ type FilterableListProps<T> = {
 
 const COL_WIDTH = 120
 
-export default function FilterableList<T>({ title, items, getKey, getName, getPreviewSrc, getGroup, selectedKey, onSelect, selectedKeys, onSelectedKeysChange, renderItem, toolbar, actions, drawer, subheader, empty, maxHeight = '60vh', grid: gridProp, viewMode: viewModeProp }: FilterableListProps<T>) {
+export default function FilterableList<T>({ title, items, getKey, getName, getPreviewSrc, getGroup, selectedKey, onSelect, onRename, selectedKeys, onSelectedKeysChange, renderItem, toolbar, actions, drawer, subheader, empty, maxHeight = '60vh', grid: gridProp, viewMode: viewModeProp }: FilterableListProps<T>) {
   const multiSelect = !!(selectedKeys && onSelectedKeysChange)
   const [hoverThumb, setHoverThumb] = useState<{ src: string; x: number; y: number } | null>(null)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
@@ -143,6 +144,21 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
 
   const hasSubheader = true
   const selectedItem = selectedKey ? items.find(i => getKey(i) === selectedKey) : null
+  const [renaming, setRenaming] = useState(false)
+  useEffect(() => { setRenaming(false) }, [selectedKey])
+  const commitRename = (value: string) => {
+    setRenaming(false)
+    if (!selectedItem) return
+    const name = value.trim()
+    if (!name || name === getName(selectedItem)) return
+    onRename?.(getKey(selectedItem), name)
+  }
+  const renameButton = onRename && selectedItem ? (
+    <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" title="Rename"
+      onClick={() => setRenaming(true)}>
+      <TextCursorInput className="h-4 w-4" />
+    </button>
+  ) : null
   const selectedIdx = selectedItem ? filtered.indexOf(selectedItem) : -1
   const previewSrc = selectedItem && getPreviewSrc ? getPreviewSrc(selectedItem) : ''
   const showBigPreview = mode === 'preview' && getPreviewSrc && selectedItem
@@ -170,7 +186,18 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
         {drawer && <div className="shrink-0">{drawer}</div>}
         {hasSubheader && (
           <div className="flex items-center gap-1 px-2 py-1 border-b shrink-0">
-            {showBigPreview ? (<>
+            {renaming && selectedItem ? (
+              <input
+                autoFocus
+                defaultValue={getName(selectedItem)}
+                className="flex-1 min-w-0 h-6 rounded border bg-background px-2 text-xs outline-none focus:ring-1 focus:ring-primary"
+                onBlur={(e) => commitRename(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+                  if (e.key === 'Escape') { (e.target as HTMLInputElement).value = getName(selectedItem); setRenaming(false) }
+                }}
+              />
+            ) : showBigPreview ? (<>
               <span className="text-xs font-medium truncate">{getName(selectedItem!)}</span>
               <div className="flex items-center gap-1 ml-auto">
                 <button className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-30 transition-colors"
@@ -182,6 +209,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
                   disabled={selectedIdx >= filtered.length - 1}
                   onClick={() => { if (selectedIdx < filtered.length - 1) onSelect?.(getKey(filtered[selectedIdx + 1])) }}
                   title="Next"><ChevronRight className="h-3.5 w-3.5" /></button>
+                {renameButton}
                 {actions}
               </div>
             </>) : (<>
@@ -205,6 +233,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
               </>}
 
               <div className="flex items-center gap-1 ml-auto">
+                {renameButton}
                 {actions}
               </div>
             </>)}

--- a/src/components/FontManager.tsx
+++ b/src/components/FontManager.tsx
@@ -7,7 +7,7 @@ import ConfirmButton from './ConfirmButton'
 import ListItem from './ListItem'
 import FilterableList from '@/components/FilterableList'
 import CollapsibleHeader, { useCollapsible } from '@/components/ui/CollapsibleHeader'
-import { useAddGoogleFont, useUploadFont, useDeleteFont } from '../hooks/useGameData'
+import { useAddGoogleFont, useUploadFont, useDeleteFont, useRenameFont } from '../hooks/useGameData'
 
 type FontEntry = { name: string; file: string; source: 'upload' | 'google' }
 
@@ -28,13 +28,14 @@ export default function FontManager({ gameId, fonts, onFontsChange, onStatus, sh
   const addGoogleFontMut = useAddGoogleFont(gameId)
   const uploadFontMut = useUploadFont(gameId)
   const deleteFontMut = useDeleteFont(gameId)
+  const renameFontMut = useRenameFont(gameId)
 
   const [showAddFormInternal, setShowAddFormInternal] = useState(false)
   const showAddForm = showAdd ?? showAddFormInternal
   const setShowAddForm = onToggleAdd ? () => onToggleAdd() : setShowAddFormInternal
   const [source, setSource] = useState<'google' | 'upload'>('google')
   const [googleFontName, setGoogleFontName] = useState('')
-  const loading = addGoogleFontMut.isPending || uploadFontMut.isPending || deleteFontMut.isPending
+  const loading = addGoogleFontMut.isPending || uploadFontMut.isPending || deleteFontMut.isPending || renameFontMut.isPending
 
   // Load font CSS for previews
   useEffect(() => {
@@ -109,6 +110,16 @@ export default function FontManager({ gameId, fonts, onFontsChange, onStatus, sh
         getName={([, font]) => font.name}
         selectedKey={selectedFont}
         onSelect={onSelectFont}
+        onRename={async (slot, newName) => {
+          onStatus('Renaming font...')
+          try {
+            await renameFontMut.mutateAsync({ slot, newName })
+            onFontsChange()
+            onStatus('Font renamed.')
+          } catch (err: any) {
+            onStatus(`Error: ${err.message}`)
+          }
+        }}
         toolbar={
           <Button size="sm" variant="ghost" onClick={() => setShowAddForm(true)} title="Add font">
             <Plus className="h-4 w-4" />

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -369,11 +369,29 @@ export function useDeleteFont(gameId: string | undefined) {
   })
 }
 
+export function useRenameFont(gameId: string | undefined) {
+  const storage = useStorageInstance()!
+  const qc = useQueryClient()
+  return useMutation<any, Error, { slot: string; newName: string }>({
+    mutationFn: ({ slot, newName }) => storage.renameFont(gameId!, slot, newName),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.fonts(gameId!) }) },
+  })
+}
+
 export function useUploadImage(gameId: string | undefined) {
   const storage = useStorageInstance()!
   const qc = useQueryClient()
   return useMutation<string, Error, File>({
     mutationFn: (file: File) => storage.uploadImage(gameId!, file),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.images(gameId!) }) },
+  })
+}
+
+export function useRenameImage(gameId: string | undefined) {
+  const storage = useStorageInstance()!
+  const qc = useQueryClient()
+  return useMutation<any, Error, { file: string; newName: string }>({
+    mutationFn: ({ file, newName }) => storage.renameImage(gameId!, file, newName),
     onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.images(gameId!) }) },
   })
 }

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -23,7 +23,7 @@ import {
   useCreateCollection, useUpdateCollection, useDeleteCollection,
   useCreateLayout, useSaveLayout, useCopyLayout, useDeleteLayout,
   useSaveCard, useCopyCard, useDeleteCard,
-  useUpdateGame, useUploadImage, useDeleteImage,
+  useUpdateGame, useUploadImage, useDeleteImage, useRenameImage,
   useInvalidateGame, queryKeys,
 } from '../hooks/useGameData'
 import FilesPanel from '@/components/FilesPanel'
@@ -174,6 +174,7 @@ export default function CollectionsPage() {
   const updateGameMut = useUpdateGame(gameId)
   const uploadImageMut = useUploadImage(gameId)
   const deleteImageMut = useDeleteImage(gameId)
+  const renameImageMut = useRenameImage(gameId)
   const invalidateGame = useInvalidateGame(gameId)
 
   const [layoutPreviewCards, setLayoutPreviewCards] = useState<any[]>([])
@@ -385,6 +386,10 @@ export default function CollectionsPage() {
                 setExpandedCollection(key)
                 if (gameId) { if (key) localStorage.setItem(`game:${gameId}:selectedCollection`, key); else localStorage.removeItem(`game:${gameId}:selectedCollection`) }
               }}
+              onRename={async (collectionId, name) => {
+                try { await updateCollectionMut.mutateAsync({ collectionId, updates: { name } }) }
+                catch { setStatus('Error renaming collection.') }
+              }}
               empty={collectionsLoading
                 ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                 : <p className="text-sm text-muted-foreground">No collections yet.</p>}
@@ -502,6 +507,12 @@ export default function CollectionsPage() {
                   getPreviewSrc={(card: any) => cardPreviews[card.id] || ''}
                   selectedKey={selectedCardId}
                   onSelect={setSelectedCardId}
+                  onRename={async (cardId, name) => {
+                    const card = collectionCards.find((c: any) => c.id === cardId)
+                    if (!card) return
+                    try { await saveCardMut.mutateAsync({ cardId, card: { ...card, name } }) }
+                    catch { setStatus('Error renaming card.') }
+                  }}
                   actions={selectedCardId ? (<>
                     <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" title="Edit"
                       onClick={() => { if (gameId && expandedCollection) { if (selectedCardId) localStorage.setItem(`editor:${gameId}:${expandedCollection}:selectedCard`, selectedCardId); localStorage.setItem(`editor:${gameId}:tab`, 'cards') }; navigate(`/game/${gameId}/collection/${expandedCollection}`) }}>
@@ -595,6 +606,16 @@ export default function CollectionsPage() {
                 onSelect={(key) => {
                   setSelectedLayoutId(key)
                   if (gameId) { if (key) localStorage.setItem(`game:${gameId}:selectedLayout`, key); else localStorage.removeItem(`game:${gameId}:selectedLayout`) }
+                }}
+                onRename={async (layoutId, name) => {
+                  const tpl = layouts.find((t: any) => t.id === layoutId)
+                  if (!tpl) return
+                  try {
+                    const saved = await saveLayoutMut.mutateAsync({ layoutId, layout: { ...tpl, name } })
+                    // Keep the per-id layout cache (staleTime: Infinity) in sync,
+                    // matching the optimistic-update pattern used by the editor.
+                    queryClient.setQueryData(queryKeys.layout(gameId!, layoutId), saved)
+                  } catch { setStatus('Error renaming layout.') }
                 }}
                 empty={layoutsLoading
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
@@ -737,6 +758,10 @@ export default function CollectionsPage() {
                 getPreviewSrc={img => img.url}
                 selectedKey={selectedImage}
                 onSelect={setSelectedImage}
+                onRename={async (file, name) => {
+                  try { await renameImageMut.mutateAsync({ file, newName: name }) }
+                  catch { setStatus('Error renaming image.') }
+                }}
                 empty={imagesLoading
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                   : <p className="text-sm text-muted-foreground">No images yet.</p>}

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -1052,6 +1052,10 @@ export default function GameEditorPage() {
                 getPreviewSrc={(card: any) => cardThumbnails[card.id] ?? ''}
                 selectedKey={selectedCardId}
                 onSelect={(key) => { if (key) selectCard(storage, key); else setSelectedCardId(null) }}
+                onRename={(cardId, name) => {
+                  // Local update only — the selected-card auto-save effect persists it.
+                  setCards(prev => prev.map(c => c.id === cardId ? { ...c, name } : c))
+                }}
                 empty={cardsLoading
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                   : <p className="text-sm text-muted-foreground">No cards yet.</p>}

--- a/src/pages/GamesPage.tsx
+++ b/src/pages/GamesPage.tsx
@@ -246,6 +246,15 @@ export default function GamesPage() {
             getName={(game: any) => game.name}
             selectedKey={expandedGame}
             onSelect={setExpandedGame}
+            onRename={async (gameId, name) => {
+              if (!storage) return
+              try {
+                await storage.updateGame(gameId, { name })
+                queryClient.invalidateQueries({ queryKey: queryKeys.games() })
+              } catch (err) {
+                setError('Error renaming game', err)
+              }
+            }}
             empty={!storage || gamesLoading
               ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
               : gamesError

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,15 @@ const saveGameFonts = (gameId: string, fonts: Record<string, FontEntry>) => {
   writeJson(gameFontsManifest(gameId), fonts);
 };
 const imagesDir = (gameId: string) => path.join(dataRoot, gameId, "images");
+// Display names for hash-named image files, kept in a sidecar manifest
+// (excluded from listings because it has no image extension).
+const imageNamesPath = (gameId: string) => path.join(imagesDir(gameId), "_names.json");
+const loadImageNames = (gameId: string): Record<string, string> =>
+  readJson<Record<string, string>>(imageNamesPath(gameId), {});
+const saveImageNames = (gameId: string, names: Record<string, string>) => {
+  fs.mkdirSync(imagesDir(gameId), { recursive: true });
+  writeJson(imageNamesPath(gameId), names);
+};
 const ttsDir = (gameId: string) => path.join(dataRoot, gameId, "tts");
 
 const hashBuffer = (data: Buffer): string =>
@@ -696,12 +705,25 @@ app.delete("/api/games/:gameId/fonts/:file", (req, res) => {
   res.json({ fonts });
 });
 
+app.post("/api/games/:gameId/fonts/:slot/rename", (req, res) => {
+  const { gameId, slot } = req.params;
+  const newName = String(req.body?.newName ?? "").trim();
+  if (!newName) return res.status(400).json({ error: "Name required" });
+  const fonts = loadGameFonts(gameId);
+  if (!fonts[slot]) return res.status(404).json({ error: "Font not found" });
+  fonts[slot] = { ...fonts[slot], name: newName };
+  saveGameFonts(gameId, fonts);
+  touchGame(gameId);
+  res.json({ fonts });
+});
+
 // Images
 app.get("/api/games/:gameId/images", (req, res) => {
   const dir = imagesDir(req.params.gameId);
   if (!fs.existsSync(dir)) return res.json([]);
+  const names = loadImageNames(req.params.gameId);
   const files = fs.readdirSync(dir).filter(f => /\.(png|jpg|jpeg|webp|gif|svg)$/i.test(f));
-  res.json(files.map(f => ({ file: f, url: `/api/games/${req.params.gameId}/images/${f}` })));
+  res.json(files.map(f => ({ file: f, url: `/api/games/${req.params.gameId}/images/${f}`, name: names[f] || f })));
 });
 
 app.post("/api/games/:gameId/images/upload", express.raw({ type: "*/*", limit: "50mb" }), (req, res) => {
@@ -719,7 +741,23 @@ app.post("/api/games/:gameId/images/upload", express.raw({ type: "*/*", limit: "
   const dir = imagesDir(gameId);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, fileName), data);
+  const names = loadImageNames(gameId);
+  if (!names[fileName]) {
+    names[fileName] = path.basename(originalName, ext) || fileName;
+    saveImageNames(gameId, names);
+  }
   res.status(201).json({ file: fileName, url: `/api/games/${gameId}/images/${fileName}` });
+});
+
+app.post("/api/games/:gameId/images/:file/rename", (req, res) => {
+  const { gameId, file } = req.params;
+  const newName = String(req.body?.newName ?? "").trim();
+  if (!newName) return res.status(400).json({ error: "Name required" });
+  if (!fs.existsSync(path.join(imagesDir(gameId), file))) return res.status(404).json({ error: "Not found" });
+  const names = loadImageNames(gameId);
+  names[file] = newName;
+  saveImageNames(gameId, names);
+  res.json({ file, name: newName });
 });
 
 app.get("/api/games/:gameId/images/:file", (req, res) => {
@@ -730,6 +768,11 @@ app.get("/api/games/:gameId/images/:file", (req, res) => {
 
 app.delete("/api/games/:gameId/images/:file", (req, res) => {
   fs.rmSync(path.join(imagesDir(req.params.gameId), req.params.file), { force: true });
+  const names = loadImageNames(req.params.gameId);
+  if (names[req.params.file]) {
+    delete names[req.params.file];
+    saveImageNames(req.params.gameId, names);
+  }
   res.status(204).end();
 });
 

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -76,6 +76,9 @@ export interface StorageBackend {
   addGoogleFont(gameId: string, name: string, slotName?: string): Promise<{ fonts: FontManifest }>;
   uploadFont(gameId: string, file: File, slotName?: string): Promise<{ fonts: FontManifest }>;
   deleteFont(gameId: string, file: string): Promise<{ fonts: FontManifest }>;
+  /** Change the display name of the font in the given manifest slot. Layouts
+   * reference fonts by slot key, so renaming never breaks existing layouts. */
+  renameFont(gameId: string, slot: string, newName: string): Promise<{ fonts: FontManifest }>;
 
   uploadImage(gameId: string, file: File): Promise<string>;
   listImages(gameId: string): Promise<ImageEntry[]>;

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -611,6 +611,14 @@ export const createGoogleDriveStorage = (options = {}) => {
     return { fonts: data };
   };
 
+  const renameFont = async (gameId, slot, newName) => {
+    const { fid, data } = await gameFontsManifest(gameId);
+    if (!data[slot]) throw new Error("Font not found");
+    data[slot] = { ...data[slot], name: newName };
+    await writeFile(fid, data);
+    return { fonts: data };
+  };
+
   // --- Images ---
 
   // Binary (non-JSON) files in a folder, cached like the JSON listings.
@@ -760,7 +768,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     listLayouts, getLayout, saveLayout, createLayout, deleteLayout, copyLayout,
     listCollections, getCollection, createCollection, updateCollection, deleteCollection,
     listCards, getCard, saveCard, deleteCard, copyCard,
-    listFonts, addGoogleFont, uploadFont, deleteFont,
+    listFonts, addGoogleFont, uploadFont, deleteFont, renameFont,
     uploadImage, listImages, deleteImage, renameImage,
     listCheckpoints, createCheckpoint, restoreCheckpoint, deleteCheckpoint,
     clearCache,

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -669,6 +669,19 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
       }
     },
 
+    async renameFont(gameId, slot, newName) {
+      const db = await openDB();
+      try {
+        const fonts = await getFontManifest(db, gameId);
+        if (!fonts[slot]) throw new Error("Font not found");
+        fonts[slot] = { ...fonts[slot], name: newName };
+        await saveFontManifest(db, gameId, fonts);
+        return { fonts };
+      } finally {
+        db.close();
+      }
+    },
+
     // ── Images ─────────────────────────────────────────────────────────────
 
     async listImages(gameId) {

--- a/src/storage/localFile.js
+++ b/src/storage/localFile.js
@@ -226,6 +226,16 @@ export const createLocalFileStorage = ({ defaultLayout }) => {
       return await response.json();
     },
 
+    async renameFont(gameId, slot, newName) {
+      const response = await fetch(`${apiBase}/games/${gameId}/fonts/${encodeURIComponent(slot)}/rename`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newName }),
+      });
+      if (!response.ok) throw new Error("Failed to rename font");
+      return await response.json();
+    },
+
     // Images
     async listImages(gameId) {
       const response = await fetch(`${apiBase}/games/${gameId}/images`);

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -559,6 +559,14 @@ export const createS3Storage = (options = {}) => {
       return { fonts };
     },
 
+    async renameFont(gameId, slot, newName) {
+      const fonts = await getFontManifest(gameId);
+      if (!fonts[slot]) throw new Error("Font not found");
+      fonts[slot] = { ...fonts[slot], name: newName };
+      await saveFontManifest(gameId, fonts);
+      return { fonts };
+    },
+
     // ── Images ─────────────────────────────────────────────────────────────
 
     async uploadImage(gameId, file) {

--- a/test/fonts.test.js
+++ b/test/fonts.test.js
@@ -107,6 +107,40 @@ describe("Font endpoints", () => {
     assert.ok(body.fonts, "Response should have fonts property");
   });
 
+  test("POST /api/games/:gameId/fonts/:slot/rename updates the display name only", async () => {
+    // The upload above created slot "test font" (basename with -/_ mapped to spaces)
+    const slot = "test font";
+    const res = await fetch(`${BASE}/api/games/${gameId}/fonts/${encodeURIComponent(slot)}/rename`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ newName: "Renamed Font" }),
+    });
+    assert.equal(res.status, 200, "Should return 200");
+    const body = await res.json();
+    assert.equal(body.fonts[slot].name, "Renamed Font", "Name should be updated");
+    assert.equal(body.fonts[slot].source, "upload", "Source should be preserved");
+    assert.ok(body.fonts[slot].file, "File should be preserved");
+
+    const list = await (await fetch(`${BASE}/api/games/${gameId}/fonts`)).json();
+    assert.equal(list[slot].name, "Renamed Font", "Rename should persist");
+  });
+
+  test("POST fonts rename returns 404 for unknown slot and 400 for empty name", async () => {
+    const missing = await fetch(`${BASE}/api/games/${gameId}/fonts/nope/rename`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ newName: "X" }),
+    });
+    assert.equal(missing.status, 404);
+
+    const empty = await fetch(`${BASE}/api/games/${gameId}/fonts/${encodeURIComponent("test font")}/rename`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ newName: "  " }),
+    });
+    assert.equal(empty.status, 400);
+  });
+
   test("DELETE /api/games/:gameId/fonts/:file removes the font file", async () => {
     assert.ok(downloadedFontFile, "Should have a downloaded font file from previous test");
 

--- a/test/serverSecurity.test.js
+++ b/test/serverSecurity.test.js
@@ -94,6 +94,47 @@ test("server: updateGame merges arbitrary fields like the other backends", async
   assert.equal(updated.id, game.id);
 });
 
+test("server: image upload records a display name and rename updates it", async () => {
+  const create = await fetch(`${BASE}/api/games`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Image Game" }),
+  });
+  const game = await create.json();
+
+  const up = await fetch(`${BASE}/api/games/${game.id}/images/upload`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      "Content-Disposition": 'attachment; filename="hero.png"',
+    },
+    body: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+  });
+  assert.equal(up.status, 201);
+  const { file } = await up.json();
+
+  let list = await (await fetch(`${BASE}/api/games/${game.id}/images`)).json();
+  assert.equal(list.find(i => i.file === file)?.name, "hero", "display name defaults to the original filename");
+
+  const rename = await fetch(`${BASE}/api/games/${game.id}/images/${file}/rename`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ newName: "villain" }),
+  });
+  assert.equal(rename.status, 200);
+
+  list = await (await fetch(`${BASE}/api/games/${game.id}/images`)).json();
+  assert.equal(list.find(i => i.file === file)?.name, "villain", "rename must persist");
+  assert.ok(!list.some(i => i.file === "_names.json"), "the names sidecar must not be listed as an image");
+
+  const missing = await fetch(`${BASE}/api/games/${game.id}/images/nope.png/rename`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ newName: "x" }),
+  });
+  assert.equal(missing.status, 404, "renaming a missing image must 404");
+});
+
 test("server: rendered card SVG uses the game's configured fonts", async () => {
   const create = await fetch(`${BASE}/api/games`, {
     method: "POST",


### PR DESCRIPTION
## Summary

None of the lists (games, collections, cards, layouts, fonts, images) offered a way to rename the selected item in place — renaming required navigating into an editor page, or was simply impossible (fonts, images on the local server backend).

`FilterableList` now accepts an `onRename` prop:
- a **Rename** button appears in the selected item's action row (all view modes, including preview),
- clicking it swaps the list subheader for an inline name input — Enter/blur commits, Escape cancels, empty or unchanged names are no-ops.

All seven list instances are wired up:

| List | Persistence path |
|---|---|
| Games | `storage.updateGame` |
| Collections | `updateCollection` |
| Cards (collections page) | `saveCard` |
| Cards (game editor) | local state + existing auto-save |
| Layouts | `saveLayout` (per-id query cache kept in sync) |
| Fonts | **new** `renameFont` backend method |
| Images | existing `renameImage` (was never wired into the UI) |

## Backend changes

- `renameFont(gameId, slot, newName)` added to the `StorageBackend` interface and all four backends (localFile, indexedDB, s3, googleDrive), plus `POST /api/games/:gameId/fonts/:slot/rename` on the server. Layouts reference fonts by slot key, so renaming the display name never breaks existing layouts.
- The localFile server had no image rename endpoint even though `localFile.js` called one, and its image listing had no display names at all. Added `POST /api/games/:gameId/images/:file/rename` backed by a `_names.json` sidecar (same scheme the browser backends already use), seeded the display name from the original filename at upload, and cleaned it up on delete.
- New `useRenameFont` / `useRenameImage` mutation hooks.

## Tests

- `fonts.test.js`: slot rename persists name while preserving file/source; 404 on unknown slot, 400 on empty name.
- `serverSecurity.test.js`: image display-name lifecycle — upload seeds name from filename, rename persists, `_names.json` never appears in the listing, 404 for missing files.
- Full suite: **183/183 pass**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAQ87KDAHYs5ZrykUc7tL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAQ87KDAHYs5ZrykUc7tL2)_