### PR TITLE
Remove layout display and selector from collection list

### DIFF
--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Input } from '@/components/ui/input'
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
 import { ArrowLeft, Pencil, Copy, Plus, Check, Layers, Loader2 } from 'lucide-react'
 import ConfirmButton from '@/components/ConfirmButton'
 import ListItem from '@/components/ListItem'
@@ -421,23 +420,6 @@ export default function CollectionsPage() {
                   }}>
                     <Copy className="h-4 w-4" />
                   </button>
-                  <Select
-                    value={col.layoutId}
-                    onValueChange={async (newLayoutId) => {
-                      if (newLayoutId === col.layoutId) return
-                      try { await updateCollectionMut.mutateAsync({ collectionId: col.id, updates: { layoutId: newLayoutId } }) }
-                      catch { setStatus('Error changing layout.') }
-                    }}
-                  >
-                    <SelectTrigger className="h-7 w-auto max-w-[8rem] gap-1 border-none bg-transparent px-1.5 text-xs text-muted-foreground hover:text-foreground focus:ring-0" title="Collection layout" aria-label="Collection layout">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {layouts.map((l: any) => (
-                        <SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                   <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" onClick={() => {
                     setSelectedLayoutId(col.layoutId)
                     setSearchParams({ tab: 'layouts' }, { replace: true })
@@ -483,14 +465,11 @@ export default function CollectionsPage() {
                   <Button size="sm" variant="outline" type="submit" className="w-full border-green-600 text-green-600 hover:bg-green-600 hover:text-white"><Check className="h-4 w-4" /></Button>
                 </form>
               ) : undefined}
-              renderItem={(col: any, _vm, selected) => {
-                    const layoutName = layouts.find((l: any) => l.id === col.layoutId)?.name
-                    return (
+              renderItem={(col: any, _vm, selected) => (
                     <ListItem selected={selected}>
                       <span className="font-medium truncate">{col.name}</span>
-                      {layoutName && <span className="ml-2 shrink-0 text-xs text-muted-foreground">{layoutName}</span>}
                     </ListItem>
-                  )}}
+                  )}
                 />
             <div className="space-y-4 min-w-0">
               {expandedCollection ? (


### PR DESCRIPTION
The collection list on the Collections tab no longer shows or edits a collection's layout:

- Removed the layout dropdown (`Select`) from the selected collection's action bar, along with the now-unused `@/components/ui/select` import.
- Removed the layout name badge from each collection row in the list.

The layout picker in the "new collection" form is kept, since a collection still needs a layout at creation time, and the "Edit layout" (Layers) shortcut button is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162q5cS6mmQobKuPMS7AyVy

---
_Generated by [Claude Code](https://claude.ai/code/session_0162q5cS6mmQobKuPMS7AyVy)_