### PR TITLE
Card backs as their own layout

### DIFF
--- a/src/components/FilesPanel.tsx
+++ b/src/components/FilesPanel.tsx
@@ -20,7 +20,7 @@ const svgToImage = (svg: string): Promise<HTMLImageElement> =>
     img.src = `data:image/svg+xml,${encodeURIComponent(svg)}`
   })
 
-export type FileCard = CardData & { collectionId?: string; collectionName?: string; collectionBack?: string; collectionBackFit?: string }
+export type FileCard = CardData & { collectionId?: string; collectionName?: string; collectionBack?: string; collectionBackFit?: string; collectionBackLayoutId?: string }
 
 type FilesPanelProps = {
   gameId: string
@@ -33,6 +33,8 @@ type FilesPanelProps = {
   storage?: any
   back?: string
   backFit?: "cover" | "contain" | "fill"
+  backLayoutId?: string
+  allLayouts?: CardLayout[]
   onStatusChange?: (msg: string) => void
   onCardsChange?: () => void
 }
@@ -40,7 +42,7 @@ type FilesPanelProps = {
 export default function FilesPanel({
   gameId, collectionId, gameName, collectionName,
   cards, layout, gameFonts,
-  back, backFit,
+  back, backFit, backLayoutId, allLayouts,
   onStatusChange,
 }: FilesPanelProps) {
   const navigate = useNavigate()
@@ -116,15 +118,15 @@ export default function FilesPanel({
         if (!resp.ok) throw new Error(`Upload failed: ${resp.status}`)
       }
 
-      type DeckGroup = { name: string; cards: FileCard[]; back?: string; backFit?: string }
+      type DeckGroup = { name: string; cards: FileCard[]; back?: string; backFit?: string; backLayoutId?: string }
       let groups: DeckGroup[]
       if (collectionId) {
-        groups = [{ name: collectionName || 'deck', cards: selected, back, backFit }]
+        groups = [{ name: collectionName || 'deck', cards: selected, back, backFit, backLayoutId }]
       } else {
         const byCol = new Map<string, DeckGroup>()
         for (const card of selected) {
           const key = card.collectionName || 'deck'
-          if (!byCol.has(key)) byCol.set(key, { name: key, cards: [], back: card.collectionBack, backFit: card.collectionBackFit })
+          if (!byCol.has(key)) byCol.set(key, { name: key, cards: [], back: card.collectionBack, backFit: card.collectionBackFit, backLayoutId: card.collectionBackLayoutId })
           byCol.get(key)!.cards.push(card)
         }
         groups = [...byCol.values()]
@@ -181,7 +183,21 @@ export default function FilesPanel({
         backCanvas.height = cardH
         const backCtx = backCanvas.getContext('2d')!
 
-        if (group.back) {
+        // A TTS deck shares one back image, so a layout-based back is rendered
+        // once with an empty card (defaults only, no per-card bindings).
+        const backLayout = group.backLayoutId ? allLayouts?.find(l => l.id === group.backLayoutId) : undefined
+        if (backLayout) {
+          try {
+            let svg = renderCardSvg({ id: 'back', name: '', fields: {} }, backLayout, { fonts: gameFonts })
+            if (fontCss) svg = svg.replace(/(<svg[^>]*>)/, `$1<defs><style>${fontCss}</style></defs>`)
+            svg = await embedImagesInSvg(svg)
+            const backImg = await svgToImage(svg)
+            backCtx.drawImage(backImg, 0, 0, cardW, cardH)
+          } catch {
+            backCtx.fillStyle = '#1b1a17'
+            backCtx.fillRect(0, 0, cardW, cardH)
+          }
+        } else if (group.back) {
           try {
             const resp = await fetch(group.back)
             const backImg = await createImageBitmap(await resp.blob())

--- a/src/gameZip.ts
+++ b/src/gameZip.ts
@@ -187,8 +187,10 @@ export const importGameZip = async (
     log(`Creating collection: ${col.id} (${col.name}) → layout: ${col.layoutId}`)
     const newCol = await storage.createCollection(newGameId, col.name, col.layoutId)
     const newColId = newCol.id
-    // Preserve extra collection fields (back, backFit, etc.)
+    // Preserve extra collection fields (backLayoutId, back, backFit, etc.)
+    // Layout ids are preserved verbatim on import, so backLayoutId needs no remap.
     const extraFields: Record<string, unknown> = {}
+    if (col.backLayoutId) extraFields.backLayoutId = col.backLayoutId
     if (col.back) extraFields.back = rewriteAll(col.back)
     if (col.backFit) extraFields.backFit = col.backFit
     if (Object.keys(extraFields).length > 0) {

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -58,7 +58,7 @@ function GameFilesPanel({ gameId, game, layouts, collections, gameFonts, onStatu
         const colCards = queryClient.getQueryData<any[]>(queryKeys.cards(gameId, col.id))
           ?? await queryClient.fetchQuery({ queryKey: queryKeys.cards(gameId, col.id), queryFn: () => storage.listCards(gameId, col.id) })
           ?? []
-        cards.push(...colCards.map((c: any) => ({ ...c, collectionId: col.id, collectionName: col.name, collectionBack: col.back, collectionBackFit: col.backFit })))
+        cards.push(...colCards.map((c: any) => ({ ...c, collectionId: col.id, collectionName: col.name, collectionBack: col.back, collectionBackFit: col.backFit, collectionBackLayoutId: col.backLayoutId })))
       }
       if (!cancelled) setAllCards(cards)
     }
@@ -73,6 +73,7 @@ function GameFilesPanel({ gameId, game, layouts, collections, gameFonts, onStatu
       cards={allCards}
       layout={layout}
       gameFonts={gameFonts}
+      allLayouts={layouts}
       onStatusChange={onStatusChange}
     />
   )

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -513,6 +513,7 @@ export default function GameEditorPage() {
   const { data: gameImages = [] } = useImages(gameId)
   const { data: allLayouts = [] } = useLayouts(gameId)
   const { data: queryLayout } = useLayout(gameId, collection?.layoutId)
+  const { data: backLayout } = useLayout(gameId, collection?.backLayoutId ?? undefined)
   const { data: queryCards, isLoading: cardsLoading } = useCards(gameId, collectionId)
 
   // ── Mutation hooks ──────────────────────────────────────────────
@@ -534,6 +535,13 @@ export default function GameEditorPage() {
     if (!gameData || !queryLayout) return null
     return { ...gameData, layout: queryLayout }
   }, [gameData, queryLayout])
+
+  // Guard against keepPreviousData serving a stale layout after backLayoutId
+  // is cleared or changed.
+  const resolvedBackLayout = useMemo(() => {
+    if (!collection?.backLayoutId || !backLayout) return null
+    return backLayout.id === collection.backLayoutId ? backLayout : null
+  }, [collection?.backLayoutId, backLayout])
 
   // Cards: local state seeded from query, kept local for editing
   const [cards, setCards] = useState<any[]>([])
@@ -583,6 +591,7 @@ export default function GameEditorPage() {
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null)
   const selectedCard = useMemo(() => cards.find(c => c.id === selectedCardId) ?? null, [cards, selectedCardId])
   const [cardPreview, setCardPreview] = useState<string>('')
+  const [backPreview, setBackPreview] = useState<string>('')
   const [editingName, setEditingName] = useState(false)
   const [editingColName, setEditingColName] = useState(false)
   const [savedCardJson, setSavedCardJson] = useState('')
@@ -718,6 +727,33 @@ export default function GameEditorPage() {
     }, 100)
     return () => { cancelled = true; clearTimeout(timer) }
   }, [selectedCard, game?.layout, gameId, collection?.back])
+
+  // Render the card back from its layout (when the collection uses one).
+  // The back layout is rendered with the selected card's data so bound
+  // properties work; a static back simply binds nothing.
+  useEffect(() => {
+    if (!resolvedBackLayout || !gameId) {
+      setBackPreview(prev => { if (prev) URL.revokeObjectURL(prev); return '' })
+      return
+    }
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      try {
+        const { renderCardSvg, embedFontsInSvg, embedImagesInSvg } = await import('../render')
+        if (cancelled) return
+        const card = selectedCard ?? { id: 'back', name: '', fields: {} }
+        let svg = renderCardSvg(card, resolvedBackLayout, { fonts: gameFonts })
+        svg = await embedFontsInSvg(svg, gameId, gameFonts)
+        svg = await embedImagesInSvg(svg)
+        if (cancelled) return
+        const blobUrl = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml' }))
+        setBackPreview(prev => { if (prev) URL.revokeObjectURL(prev); return blobUrl })
+      } catch (error) {
+        if (!cancelled) console.error('Error updating back preview:', error)
+      }
+    }, 100)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [selectedCard, resolvedBackLayout, gameId])
 
   // Generate thumbnails for detailed/gallery views — only re-render all on layout change or card add/remove
   const cardsRef = useRef(cards)
@@ -1219,7 +1255,12 @@ export default function GameEditorPage() {
               )}
 
               {cardPreview && (
-                <ZoomablePreview src={cardPreview} alt="Card preview" backImage={collection?.back} backFit={collection?.backFit} />
+                <ZoomablePreview
+                  src={cardPreview}
+                  alt="Card preview"
+                  backImage={resolvedBackLayout ? (backPreview || undefined) : collection?.back}
+                  backFit={resolvedBackLayout ? 'fill' : collection?.backFit}
+                />
               )}
             </div>
           </TabsContent>
@@ -1280,29 +1321,55 @@ export default function GameEditorPage() {
           </TabsContent>
 
           <TabsContent value="back">
-            {collection?.back && (
-              <ZoomablePreview src={collection.back} alt="Back preview" maxImgHeight="30vh" />
+            {resolvedBackLayout ? (
+              backPreview && <ZoomablePreview src={backPreview} alt="Back preview" maxImgHeight="30vh" />
+            ) : (
+              collection?.back && <ZoomablePreview src={collection.back} alt="Back preview" maxImgHeight="30vh" />
             )}
             <Card>
               <CardContent className="pt-6 space-y-4">
                 <div className="space-y-2">
-                  <Label>Card Back Image</Label>
-                  <ValueItemEditor
-                    property="defaultValue"
-                    itemType="image"
-                    value={collection?.back || ''}
-                    layout={game?.layout}
-                    gameImages={gameImages}
-                    onUploadFile={async (file) => {
-                      return await uploadImageMut.mutateAsync(file)
+                  <Label>Back Layout</Label>
+                  <select
+                    value={collection?.backLayoutId ?? ''}
+                    onChange={async (e) => {
+                      const v = e.target.value
+                      try { await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { backLayoutId: v || null } }) }
+                      catch { setStatus('Error saving back layout.') }
                     }}
-                    onChange={async (v) => {
-                      try { await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { back: v || undefined } }) }
-                      catch { setStatus('Error saving back.') }
-                    }}
-                  />
+                    className="w-full rounded-md border bg-background pl-3 pr-8 py-1.5 text-sm"
+                  >
+                    <option value="">None (use image)</option>
+                    {allLayouts.map((l: any) => (
+                      <option key={l.id} value={l.id}>{l.name}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground">
+                    {collection?.backLayoutId
+                      ? 'The back is rendered from this layout, like the card front. Edit it from the game\'s layouts page.'
+                      : 'Pick a layout to design the card back, or use a static image below.'}
+                  </p>
                 </div>
-                {collection?.back && (
+                {!collection?.backLayoutId && (
+                  <div className="space-y-2">
+                    <Label>Card Back Image</Label>
+                    <ValueItemEditor
+                      property="defaultValue"
+                      itemType="image"
+                      value={collection?.back || ''}
+                      layout={game?.layout}
+                      gameImages={gameImages}
+                      onUploadFile={async (file) => {
+                        return await uploadImageMut.mutateAsync(file)
+                      }}
+                      onChange={async (v) => {
+                        try { await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { back: v || undefined } }) }
+                        catch { setStatus('Error saving back.') }
+                      }}
+                    />
+                  </div>
+                )}
+                {!collection?.backLayoutId && collection?.back && (
                   <div className="space-y-2">
                     <FloatingSelect
                       label="Fit Mode"
@@ -1358,6 +1425,8 @@ export default function GameEditorPage() {
               gameFonts={gameFonts}
               back={collection?.back}
               backFit={collection?.backFit}
+              backLayoutId={collection?.backLayoutId}
+              allLayouts={allLayouts}
               onStatusChange={setStatus}
               onCardsChange={() => { invalidateGame(); cardsInitialized.current = false }}
             />

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -103,7 +103,7 @@ function computePageLayout(config: PrintConfig, cardWidthMm: number, cardHeightM
 
 // --- Component ---
 
-type CardEntry = { card: CardData; layout: CardLayout; collectionName: string; back?: string; backFit?: string }
+type CardEntry = { card: CardData; layout: CardLayout; collectionName: string; back?: string; backFit?: string; backLayout?: CardLayout }
 
 export default function PrintPage() {
   const { gameId, collectionId } = useParams<{ gameId: string; collectionId?: string }>()
@@ -117,6 +117,7 @@ export default function PrintPage() {
 
   const [entries, setEntries] = useState<CardEntry[]>([])
   const [svgs, setSvgs] = useState<string[]>([])
+  const [backSvgs, setBackSvgs] = useState<(string | null)[]>([])
   const [status, setStatus] = useState('Loading...')
   const [exporting, setExporting] = useState(false)
   // Open by default on desktop; on mobile the settings start as a closed
@@ -188,13 +189,14 @@ export default function PrintPage() {
 
         const all: CardEntry[] = []
         for (const col of collections) {
-          const [tpl, cards] = await Promise.all([
+          const [tpl, cards, backTpl] = await Promise.all([
             storage.getLayout(gameId, col.layoutId),
             storage.listCards(gameId, col.id),
+            col.backLayoutId ? storage.getLayout(gameId, col.backLayoutId).catch(() => null) : Promise.resolve(null),
           ])
           for (const card of cards) {
             if (cardIdSet && !cardIdSet.has(card.id)) continue
-            all.push({ card, layout: tpl, collectionName: col.name, back: col.back, backFit: col.backFit })
+            all.push({ card, layout: tpl, collectionName: col.name, back: col.back, backFit: col.backFit, backLayout: backTpl ?? undefined })
           }
         }
 
@@ -219,14 +221,23 @@ export default function PrintPage() {
     let cancelled = false
     ;(async () => {
       const rendered: string[] = []
-      for (const { card, layout } of entries) {
+      const renderedBacks: (string | null)[] = []
+      for (const { card, layout, backLayout } of entries) {
         if (cancelled) return
         let svg = renderCardSvg(card, layout, { fonts: gameFonts })
         svg = await embedFontsInSvg(svg, gameId!, gameFonts)
         svg = await embedImagesInSvg(svg)
         rendered.push(svg)
+        if (backLayout) {
+          let bsvg = renderCardSvg(card, backLayout, { fonts: gameFonts })
+          bsvg = await embedFontsInSvg(bsvg, gameId!, gameFonts)
+          bsvg = await embedImagesInSvg(bsvg)
+          renderedBacks.push(bsvg)
+        } else {
+          renderedBacks.push(null)
+        }
       }
-      if (!cancelled) setSvgs(rendered)
+      if (!cancelled) { setSvgs(rendered); setBackSvgs(renderedBacks) }
     })()
     return () => { cancelled = true }
   }, [entries])
@@ -289,6 +300,15 @@ export default function PrintPage() {
       const isDuplexPdf = config.printMode === 'duplex'
       const foldHPdf = isFoldPdf && (config.foldEdge === 'left' || config.foldEdge === 'right')
 
+      // Resolve a card's back: a layout-rendered SVG (rasterized) wins over
+      // the collection's static back image.
+      const backImageFor = async (idx: number): Promise<{ data: string; type: 'PNG' | 'JPEG' } | null> => {
+        const bsvg = backSvgs[idx]
+        if (bsvg) return { data: await rasterizeSvg(bsvg, baseCw, baseCh), type: 'PNG' }
+        const back = entries[idx]?.back
+        return back ? { data: back, type: 'JPEG' } : null
+      }
+
       const renderPage = async (startIdx: number, isBack: boolean) => {
         const pageCardSvgs = svgs.slice(startIdx, startIdx + perPage)
         for (let i = 0; i < pageCardSvgs.length; i++) {
@@ -297,7 +317,6 @@ export default function PrintPage() {
           const row = Math.floor(i / cols)
           const x = offsetX + col * (cw + config.gap)
           const y = offsetY + row * (ch + config.gap)
-          const entry = entries[startIdx + i]
 
           if (!isBack && (config.printMode === 'front' || isFoldPdf || isDuplexPdf)) {
             const fx = isFoldPdf ? (config.foldEdge === 'right' ? x : foldHPdf ? x + baseCw : x) : x
@@ -306,26 +325,26 @@ export default function PrintPage() {
             doc.addImage(png, 'PNG', fx, fy, baseCw, baseCh)
           }
 
-          if (isBack && entry?.back) {
-            doc.addImage(entry.back, 'JPEG', x, y, baseCw, baseCh)
+          if (isBack || config.printMode === 'back') {
+            const b = await backImageFor(startIdx + i)
+            if (b) doc.addImage(b.data, b.type, x, y, baseCw, baseCh)
           }
 
-          if (!isBack && config.printMode === 'back' && entry?.back) {
-            doc.addImage(entry.back, 'JPEG', x, y, baseCw, baseCh)
-          }
-
-          if (!isBack && isFoldPdf && entry?.back) {
-            const bx = config.foldEdge === 'right' ? x + baseCw : foldHPdf ? x : x
-            const by = config.foldEdge === 'bottom' ? y + baseCh : !foldHPdf ? y : y
-            doc.saveGraphicsState()
-            if (foldHPdf) {
-              doc.setCurrentTransformationMatrix(doc.Matrix(-1, 0, 0, 1, (bx + baseCw) * 2 / doc.internal.scaleFactor, 0))
-              doc.addImage(entry.back, 'JPEG', bx, by, baseCw, baseCh)
-            } else {
-              doc.setCurrentTransformationMatrix(doc.Matrix(1, 0, 0, -1, 0, (by + baseCh) * 2 / doc.internal.scaleFactor))
-              doc.addImage(entry.back, 'JPEG', bx, by, baseCw, baseCh)
+          if (!isBack && isFoldPdf) {
+            const b = await backImageFor(startIdx + i)
+            if (b) {
+              const bx = config.foldEdge === 'right' ? x + baseCw : foldHPdf ? x : x
+              const by = config.foldEdge === 'bottom' ? y + baseCh : !foldHPdf ? y : y
+              doc.saveGraphicsState()
+              if (foldHPdf) {
+                doc.setCurrentTransformationMatrix(doc.Matrix(-1, 0, 0, 1, (bx + baseCw) * 2 / doc.internal.scaleFactor, 0))
+                doc.addImage(b.data, b.type, bx, by, baseCw, baseCh)
+              } else {
+                doc.setCurrentTransformationMatrix(doc.Matrix(1, 0, 0, -1, 0, (by + baseCh) * 2 / doc.internal.scaleFactor))
+                doc.addImage(b.data, b.type, bx, by, baseCw, baseCh)
+              }
+              doc.restoreGraphicsState()
             }
-            doc.restoreGraphicsState()
           }
 
           if (config.cutMarks) {
@@ -521,18 +540,27 @@ export default function PrintPage() {
                           )}
                         </div>
                       )}
-                      {showBack && entry.back && (
+                      {showBack && (backSvgs[svgIdx] || entry.back) && (
                         <div style={config.printMode === 'back' ? { width: '100%', height: '100%' } : backStyle}>
-                          <img
-                            src={entry.back}
-                            alt="Back"
-                            className="w-full h-full pointer-events-none"
-                            style={{ objectFit: (entry.backFit as any) || 'cover' }}
-                            draggable={false}
-                          />
+                          {backSvgs[svgIdx] ? (
+                            <img
+                              src={`data:image/svg+xml,${encodeURIComponent(backSvgs[svgIdx]!)}`}
+                              alt="Back"
+                              className="w-full h-full pointer-events-none"
+                              draggable={false}
+                            />
+                          ) : (
+                            <img
+                              src={entry.back}
+                              alt="Back"
+                              className="w-full h-full pointer-events-none"
+                              style={{ objectFit: (entry.backFit as any) || 'cover' }}
+                              draggable={false}
+                            />
+                          )}
                         </div>
                       )}
-                      {showBack && !entry.back && config.printMode === 'back' && (
+                      {showBack && !backSvgs[svgIdx] && !entry.back && config.printMode === 'back' && (
                         <div className="w-full h-full bg-muted flex items-center justify-center text-xs text-muted-foreground">No back</div>
                       )}
                       {isFold && (

--- a/src/server.ts
+++ b/src/server.ts
@@ -585,7 +585,7 @@ app.post("/api/games/:gameId/collections/:collectionId/checkpoints", (req, res) 
   const createdAt = new Date().toISOString();
   const checkpoint = {
     id, name, createdAt,
-    collection: { name: col.name, layoutId: col.layoutId, back: (col as any).back, backFit: (col as any).backFit },
+    collection: { name: col.name, layoutId: col.layoutId, backLayoutId: (col as any).backLayoutId, back: (col as any).back, backFit: (col as any).backFit },
     cards,
   };
   writeJson(checkpointPath(gameId, collectionId, id), checkpoint);
@@ -609,6 +609,7 @@ app.post("/api/games/:gameId/collections/:collectionId/checkpoints/:checkpointId
   writeJson(collectionPath(gameId, collectionId), {
     ...col,
     layoutId: checkpoint.collection.layoutId,
+    backLayoutId: checkpoint.collection.backLayoutId,
     back: checkpoint.collection.back,
     backFit: checkpoint.collection.backFit,
   });

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -19,7 +19,7 @@ export type CheckpointMeta = { id: string; name: string; createdAt: string };
 
 /** A named, restorable snapshot of a collection's cards + metadata. */
 export type Checkpoint = CheckpointMeta & {
-  collection: { name: string; layoutId: string; back?: string; backFit?: "cover" | "contain" | "fill" };
+  collection: { name: string; layoutId: string; backLayoutId?: string; back?: string; backFit?: "cover" | "contain" | "fill" };
   cards: CardData[];
 };
 

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -729,7 +729,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     const createdAt = now();
     const checkpoint = {
       id, name, createdAt,
-      collection: { name: col.name, layoutId: col.layoutId, back: col.back, backFit: col.backFit },
+      collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit },
       cards,
     };
     const folder = await checkpointsFolder(gameId, collectionId);
@@ -750,6 +750,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     // Restore collection metadata (layout + back), keep id/name.
     await updateCollection(gameId, collectionId, {
       layoutId: checkpoint.collection.layoutId,
+      backLayoutId: checkpoint.collection.backLayoutId,
       back: checkpoint.collection.back,
       backFit: checkpoint.collection.backFit,
     });

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -541,7 +541,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
         const createdAt = now();
         const checkpoint = {
           id, name, createdAt,
-          collection: { name: col.name, layoutId: col.layoutId, back: col.back, backFit: col.backFit },
+          collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit },
           cards,
         };
         await idbPut(db, "checkpoints", [gameId, collectionId, id], checkpoint);
@@ -567,6 +567,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
         await idbPut(db, "collections", [gameId, collectionId], {
           ...col,
           layoutId: checkpoint.collection.layoutId,
+          backLayoutId: checkpoint.collection.backLayoutId,
           back: checkpoint.collection.back,
           backFit: checkpoint.collection.backFit,
           updatedAt: now(),

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -665,7 +665,7 @@ export const createS3Storage = (options = {}) => {
       const createdAt = now();
       const checkpoint = {
         id, name, createdAt,
-        collection: { name: col.name, layoutId: col.layoutId, back: col.back, backFit: col.backFit },
+        collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit },
         cards,
       };
       await putJson(checkpointKey(gameId, collectionId, id), checkpoint);
@@ -688,6 +688,7 @@ export const createS3Storage = (options = {}) => {
       await putJson(collectionKey(gameId, collectionId), {
         ...col,
         layoutId: checkpoint.collection.layoutId,
+        backLayoutId: checkpoint.collection.backLayoutId,
         back: checkpoint.collection.back,
         backFit: checkpoint.collection.backFit,
         updatedAt: now(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,9 @@ export type Collection = {
   id: string;
   name: string;
   layoutId: string;
+  // Card back: either a dedicated layout (rendered like the front) or a
+  // static image. backLayoutId takes precedence over back/backFit when set.
+  backLayoutId?: string;
   back?: string;
   backFit?: "cover" | "contain" | "fill";
 };

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -262,7 +262,7 @@ async function startServer() {
     const { name } = await c.req.json();
     const id = uid();
     const createdAt = new Date().toISOString();
-    const checkpoint = { id, name: name || "Checkpoint", createdAt, collection: { name: col.name, layoutId: col.layoutId, back: col.back, backFit: col.backFit }, cards: listCardsFor(gid, cid) };
+    const checkpoint = { id, name: name || "Checkpoint", createdAt, collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit }, cards: listCardsFor(gid, cid) };
     writeJson(chkPath(gid, cid, id), checkpoint);
     return c.json({ id, name: checkpoint.name, createdAt }, 201);
   });
@@ -275,7 +275,7 @@ async function startServer() {
     fs.mkdirSync(cdir, { recursive: true });
     for (const card of checkpoint.cards ?? []) writeJson(cardPath(gid, cid, card.id), card);
     const col = readJson(colPath(gid, cid), {});
-    writeJson(colPath(gid, cid), { ...col, layoutId: checkpoint.collection.layoutId, back: checkpoint.collection.back, backFit: checkpoint.collection.backFit });
+    writeJson(colPath(gid, cid), { ...col, layoutId: checkpoint.collection.layoutId, backLayoutId: checkpoint.collection.backLayoutId, back: checkpoint.collection.back, backFit: checkpoint.collection.backFit });
     return c.body(null, 204);
   });
   app.delete("/api/games/:gid/collections/:cid/checkpoints/:chk", (c) => {
@@ -580,8 +580,9 @@ async function createFullTestGame(storage) {
     fields: { cost: "3", description: "*Wise* mage", faction: "🔮" },
   });
 
-  // Second collection
+  // Second collection — uses a layout-rendered back instead of an image
   const col2 = await storage.createCollection(gameId, "Expansion", tpl.id);
+  await storage.updateCollection(gameId, col2.id, { backLayoutId: tpl.id });
   await storage.saveCard(gameId, col2.id, "card-3", {
     id: "card-3", name: "Rogue",
     fields: { cost: "4", faction: "🏹" },
@@ -683,6 +684,7 @@ async function verifyFullTestGame(storage, gameId) {
   assert.ok(warrior.fields.image.includes(`/api/games/${gameId}/images/`));
 
   const expCol = cols.find(c => c.name === "Expansion");
+  assert.equal(expCol.backLayoutId, tpl.id, "backLayoutId must survive the round trip");
   const expCards = await storage.listCards(gameId, expCol.id);
   assert.equal(expCards.length, 1);
   assert.equal(expCards[0].fields.faction, "🏹");


### PR DESCRIPTION
## Summary

Card backs are no longer limited to a static image — a collection can now point its back at one of the game's layouts (`Collection.backLayoutId`), and the back is rendered exactly like the front. Since the back layout renders with each card's data, bound properties work on backs too; a purely static back simply binds nothing.

The legacy image back (`back` + `backFit`) remains as the fallback when no back layout is selected, so existing games are unaffected.

## Changes

- **Data model**: `backLayoutId?: string` on `Collection` (`src/types.ts`). It takes precedence over the `back` image when set.
- **Back tab** (GameEditorPage): new "Back Layout" selector listing the game's layouts, with a live rendered preview; the image + fit-mode controls stay available when "None (use image)" is selected. The card-preview flip animation shows the rendered back.
- **Print/PDF** (PrintPage): backs are rendered from the back layout per card, in both the on-screen preview and the exported PDF, across back-only, duplex and fold modes. Falls back to the image back as before.
- **TTS export** (FilesPanel): the deck back atlas is rendered from the back layout with an empty card (TTS decks share a single back, so no per-card bindings there).
- **Persistence**: `backLayoutId` survives zip export/import (layout ids are preserved verbatim on import, so no remapping needed) and collection checkpoints on every backend (localFile server, IndexedDB, S3, Google Drive).

## Testing

- `test/backendCompat.test.js`: the full round-trip fixture now sets `backLayoutId` on the Expansion collection and verifies it after localFile/IndexedDB/S3 and cross-backend zip transfers; the test mini-server's checkpoint endpoints mirror the real server.
- All 183 tests pass; `tsc` and the production Vite build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8)_