### PR TITLE
Detect and delete unused images and fonts

### DIFF
--- a/src/assetUsage.ts
+++ b/src/assetUsage.ts
@@ -1,0 +1,119 @@
+/**
+ * Scans game data for references to uploaded assets, so unused images and
+ * fonts can be detected (and safely deleted) and exports can skip dead files.
+ *
+ * Reference forms differ by asset type:
+ * - Images are referenced by full URL (`/api/games/{gameId}/images/{file}`)
+ *   in card field values, image item defaultValues, layout bindingMeta
+ *   defaults/values, and collection backs.
+ * - Fonts are referenced by manifest slot key (`item.font`, font bindings,
+ *   bindingMeta for `font:*`), never by URL.
+ *
+ * Checkpoints are self-contained snapshots whose contents are not readable
+ * through the storage interface, so they are NOT scanned — callers should
+ * surface that caveat when offering deletion.
+ */
+
+// Matches all occurrences in a value (rich text can embed several images)
+// and stops at quote/whitespace/markup delimiters so trailing text is not
+// captured into the filename.
+export const IMAGE_URL_RE = /\/api\/games\/[^/]+\/images\/([^"'\s<>)]+)/g
+
+type SectionLike = { items?: any[]; children?: SectionLike[] }
+
+const walkItems = (section: SectionLike | undefined | null, fn: (item: any) => void) => {
+  if (!section) return
+  for (const item of section.items ?? []) fn(item)
+  for (const child of section.children ?? []) walkItems(child, fn)
+}
+
+/** Image file names referenced anywhere in the given layouts, collections and cards. */
+export function collectUsedImageFiles(
+  layouts: any[],
+  collections: any[],
+  allCards: any[],
+): Set<string> {
+  const files = new Set<string>()
+  const collect = (val: unknown) => {
+    for (const m of String(val ?? '').matchAll(IMAGE_URL_RE)) files.add(m[1])
+  }
+  // Card field values: any field can carry an image URL when an image item
+  // is bound to it, so every value is scanned.
+  for (const card of allCards) {
+    for (const val of Object.values(card.fields ?? {})) collect(val)
+  }
+  for (const tpl of layouts) {
+    walkItems(tpl.root, (item) => collect(item.defaultValue))
+    // Binding defaults and allowed values live at layout level in bindingMeta
+    for (const meta of Object.values(tpl.bindingMeta ?? {}) as any[]) {
+      collect(meta?.default)
+      for (const v of meta?.values ?? []) collect(v)
+    }
+  }
+  for (const col of collections) collect(col.back)
+  return files
+}
+
+/**
+ * Font slot keys referenced by the given layouts and cards.
+ *
+ * The first manifest slot is always considered used: both renderers fall
+ * back to `Object.keys(fonts)[0]` whenever a text/numbers item has no
+ * (valid) font. Card field values only count as font references for fields
+ * that some item actually binds its `font` property to.
+ */
+export function collectUsedFontSlots(
+  fonts: Record<string, { name: string; file: string }>,
+  layouts: any[],
+  allCards: any[],
+): Set<string> {
+  const used = new Set<string>()
+  const slots = Object.keys(fonts)
+  if (slots.length === 0) return used
+  used.add(slots[0])
+
+  const boundFields = new Set<string>()
+  for (const tpl of layouts) {
+    walkItems(tpl.root, (item) => {
+      if (item.font) used.add(String(item.font))
+      const field = item.bindings?.font?.field
+      if (field) {
+        // resolve() checks the scoped key first, then the plain field name
+        boundFields.add(`font:${field}`)
+        boundFields.add(String(field))
+      }
+    })
+    for (const [key, meta] of Object.entries(tpl.bindingMeta ?? {}) as [string, any][]) {
+      if (!key.startsWith('font:')) continue
+      if (meta?.default) used.add(String(meta.default))
+      for (const v of meta?.values ?? []) if (v) used.add(String(v))
+    }
+  }
+  if (boundFields.size > 0) {
+    for (const card of allCards) {
+      for (const [field, val] of Object.entries(card.fields ?? {})) {
+        if (val && boundFields.has(field)) used.add(String(val))
+      }
+    }
+  }
+  return used
+}
+
+/**
+ * Slot keys that are safe to delete: not used themselves, and not sharing a
+ * font file with a used slot (deleteFont removes every slot pointing at the
+ * same file, and content-hash naming means slots can share files).
+ */
+export function findUnusedFontSlots(
+  fonts: Record<string, { name: string; file: string }>,
+  usedSlots: Set<string>,
+): string[] {
+  const usedFiles = new Set(
+    Object.entries(fonts)
+      .filter(([key, entry]) => usedSlots.has(key) && entry.file)
+      .map(([, entry]) => entry.file),
+  )
+  return Object.keys(fonts).filter(
+    (key) => !usedSlots.has(key) && !(fonts[key].file && usedFiles.has(fonts[key].file)),
+  )
+}

--- a/src/components/ConfirmButton.tsx
+++ b/src/components/ConfirmButton.tsx
@@ -8,6 +8,8 @@ type ConfirmButtonProps = {
   variant?: 'destructive' | 'outline' | 'default' | 'ghost'
   disabled?: boolean
   iconOnly?: boolean
+  title?: string
+  label?: string
 }
 
 export default function ConfirmButton({
@@ -16,6 +18,8 @@ export default function ConfirmButton({
   variant = 'destructive',
   disabled,
   iconOnly,
+  title = 'Delete',
+  label,
 }: ConfirmButtonProps) {
   const [confirming, setConfirming] = useState(false)
 
@@ -34,7 +38,7 @@ export default function ConfirmButton({
         className="rounded p-1 text-muted-foreground hover:text-destructive transition-colors disabled:opacity-30"
         disabled={disabled}
         onClick={() => setConfirming(true)}
-        title="Delete"
+        title={title}
       >
         <Trash2 className="h-4 w-4" />
       </button>
@@ -51,6 +55,7 @@ export default function ConfirmButton({
         title="Confirm delete"
       >
         <Check className="h-4 w-4" />
+        {label && <span className="ml-1">{label}</span>}
       </Button>
     )
   }
@@ -61,9 +66,10 @@ export default function ConfirmButton({
       variant={variant}
       disabled={disabled}
       onClick={() => setConfirming(true)}
-      title="Delete"
+      title={title}
     >
       <Trash2 className="h-4 w-4" />
+      {label && <span className="ml-1">{label}</span>}
     </Button>
   )
 }

--- a/src/components/FontManager.tsx
+++ b/src/components/FontManager.tsx
@@ -22,9 +22,11 @@ type FontManagerProps = {
   selectedFont: string | null
   onSelectFont: (key: string | null) => void
   isLoading?: boolean
+  /** Slot keys detected as unused; shows a badge per font and a bulk-delete button. */
+  unusedSlots?: Set<string>
 }
 
-export default function FontManager({ gameId, fonts, onFontsChange, onStatus, showAdd, onToggleAdd, selectedFont, onSelectFont, isLoading }: FontManagerProps) {
+export default function FontManager({ gameId, fonts, onFontsChange, onStatus, showAdd, onToggleAdd, selectedFont, onSelectFont, isLoading, unusedSlots }: FontManagerProps) {
   const addGoogleFontMut = useAddGoogleFont(gameId)
   const uploadFontMut = useUploadFont(gameId)
   const deleteFontMut = useDeleteFont(gameId)
@@ -99,7 +101,30 @@ export default function FontManager({ gameId, fonts, onFontsChange, onStatus, sh
     }
   }
 
+  const handleDeleteUnused = async () => {
+    if (!unusedSlots || unusedSlots.size === 0) return
+    onStatus('Deleting unused fonts...')
+    try {
+      // Dedupe: deleteFont removes every slot pointing at the same file
+      const files = new Set<string>()
+      for (const key of unusedSlots) {
+        const file = fonts[key]?.file
+        if (file) files.add(file)
+      }
+      for (const file of files) await deleteFontMut.mutateAsync(file)
+      onFontsChange()
+      if (selectedFont && unusedSlots.has(selectedFont)) {
+        const remaining = Object.keys(fonts).filter(k => !unusedSlots.has(k))
+        onSelectFont(remaining[0] ?? null)
+      }
+      onStatus(`Deleted ${files.size} unused font${files.size === 1 ? '' : 's'}.`)
+    } catch (err: any) {
+      onStatus(`Error: ${err.message}`)
+    }
+  }
+
   const fontEntries = Object.entries(fonts)
+  const unusedCount = unusedSlots ? fontEntries.filter(([key, f]) => unusedSlots.has(key) && f.file).length : 0
 
   return (
     <div className="space-y-2">
@@ -120,21 +145,33 @@ export default function FontManager({ gameId, fonts, onFontsChange, onStatus, sh
             onStatus(`Error: ${err.message}`)
           }
         }}
-        toolbar={
+        toolbar={<>
+          {unusedCount > 0 && (
+            <ConfirmButton
+              variant="ghost"
+              disabled={loading}
+              label={`${unusedCount} unused`}
+              title={`Delete ${unusedCount} unused font${unusedCount === 1 ? '' : 's'} (checkpoints are not scanned)`}
+              onConfirm={handleDeleteUnused}
+            />
+          )}
           <Button size="sm" variant="ghost" onClick={() => setShowAddForm(true)} title="Add font">
             <Plus className="h-4 w-4" />
           </Button>
-        }
+        </>}
         actions={selectedFont ? (
           <ConfirmButton iconOnly onConfirm={() => handleDelete(selectedFont)} disabled={loading} />
         ) : undefined}
         empty={isLoading
           ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
           : !showAddForm ? <p className="text-sm text-muted-foreground">No fonts yet.</p> : undefined}
-        renderItem={([, font], _vm, selected) => (
+        renderItem={([key, font], _vm, selected) => (
           <ListItem selected={selected}>
             <span className="font-medium">{font.name}</span>
             <span className="ml-2 text-xs text-muted-foreground">{font.source === 'google' ? 'Google Fonts' : 'File'}</span>
+            {unusedSlots?.has(key) && (
+              <span className="ml-2 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">unused</span>
+            )}
           </ListItem>
         )}
       />

--- a/src/gameZip.ts
+++ b/src/gameZip.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip'
+import { collectUsedImageFiles } from './assetUsage'
 
 /**
  * Export a game as a zip file containing all JSON data and binary assets.
@@ -35,45 +36,18 @@ export const exportGameZip = async (
 
   log('Exporting collections and cards...')
   const collections = await storage.listCollections(gameId)
+  const allCards: any[] = []
   for (const col of collections) {
     zip.file(`collections/${col.id}/collection.json`, JSON.stringify(col, null, 2))
     const cards = await storage.listCards(gameId, col.id)
+    allCards.push(...cards)
     for (const card of cards) {
       zip.file(`collections/${col.id}/cards/${card.id}.json`, JSON.stringify(card, null, 2))
     }
   }
 
   log('Exporting images...')
-  // Collect every referenced image file. Matches all occurrences in a value
-  // (rich text can embed several images) and stops at quote/whitespace/markup
-  // delimiters so trailing text is not captured into the filename.
-  const IMAGE_URL_RE = /\/api\/games\/[^/]+\/images\/([^"'\s<>)]+)/g
-  const imageFiles = new Set<string>()
-  const collectImageFiles = (val: unknown) => {
-    for (const m of String(val ?? '').matchAll(IMAGE_URL_RE)) imageFiles.add(m[1])
-  }
-  // Card field values
-  for (const col of collections) {
-    const cards = await storage.listCards(gameId, col.id)
-    for (const card of cards) {
-      for (const val of Object.values(card.fields ?? {})) collectImageFiles(val)
-    }
-  }
-  // Layout item default values
-  const scanItems = (section: any) => {
-    for (const item of section.items ?? []) collectImageFiles(item.defaultValue)
-    for (const child of section.children ?? []) scanItems(child)
-  }
-  for (const tpl of layouts) {
-    scanItems(tpl.root)
-    // Binding defaults and allowed values live at layout level in bindingMeta
-    for (const meta of Object.values(tpl.bindingMeta ?? {}) as any[]) {
-      collectImageFiles(meta?.default)
-      for (const v of meta?.values ?? []) collectImageFiles(v)
-    }
-  }
-  // Collection back images
-  for (const col of collections) collectImageFiles(col.back)
+  const imageFiles = collectUsedImageFiles(layouts, collections, allCards)
 
   for (const file of imageFiles) {
     try {

--- a/src/hooks/useAssetUsage.ts
+++ b/src/hooks/useAssetUsage.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { useQueries } from '@tanstack/react-query'
+import { useStorageInstance } from './useStorage'
+import { useLayouts, useCollections, useFonts, useImages, queryKeys, staleTime, gcTime } from './useGameData'
+import { collectUsedImageFiles, collectUsedFontSlots, findUnusedFontSlots } from '../assetUsage'
+
+export type AssetUsage = {
+  /** True while any of the underlying game data is still loading. */
+  isLoading: boolean
+  /** Image file names referenced by at least one layout, card or collection. */
+  usedImageFiles: Set<string>
+  /** Image file names present in storage but referenced nowhere. */
+  unusedImageFiles: Set<string>
+  /** Font slot keys that are referenced nowhere and safe to delete. */
+  unusedFontSlots: Set<string>
+}
+
+/**
+ * Scans the whole game (all layouts, all collections, all cards) for asset
+ * references and reports which uploaded images and fonts are unused.
+ * Checkpoint snapshots cannot be read through the storage interface and are
+ * not scanned.
+ */
+export default function useAssetUsage(gameId: string | undefined): AssetUsage {
+  const storage = useStorageInstance()!
+  const { data: layouts = [], isLoading: layoutsLoading } = useLayouts(gameId)
+  const { data: collections = [], isLoading: collectionsLoading } = useCollections(gameId)
+  const { data: fonts = {}, isLoading: fontsLoading } = useFonts(gameId)
+  const { data: images = [], isLoading: imagesLoading } = useImages(gameId)
+
+  const cardQueries = useQueries({
+    queries: collections.map((col: any) => ({
+      queryKey: queryKeys.cards(gameId!, col.id),
+      queryFn: () => storage.listCards(gameId!, col.id),
+      enabled: !!storage && !!gameId,
+      staleTime: staleTime(),
+      gcTime: gcTime(),
+    })),
+  })
+
+  const isLoading = layoutsLoading || collectionsLoading || fontsLoading || imagesLoading
+    || cardQueries.some((q) => q.isLoading)
+
+  // useQueries returns a fresh array every render; key the memo on the data
+  // update timestamps so the scan only reruns when something actually changed.
+  const cardsKey = cardQueries.map((q) => q.dataUpdatedAt).join(',')
+
+  return useMemo(() => {
+    const empty = {
+      isLoading,
+      usedImageFiles: new Set<string>(),
+      unusedImageFiles: new Set<string>(),
+      unusedFontSlots: new Set<string>(),
+    }
+    if (isLoading) return empty
+
+    const allCards = cardQueries.flatMap((q) => (q.data as any[]) ?? [])
+    const usedImageFiles = collectUsedImageFiles(layouts, collections, allCards)
+    const unusedImageFiles = new Set(
+      images.map((img) => img.file).filter((file) => !usedImageFiles.has(file)),
+    )
+    const usedFontSlots = collectUsedFontSlots(fonts, layouts, allCards)
+    const unusedFontSlots = new Set(findUnusedFontSlots(fonts, usedFontSlots))
+    return { isLoading, usedImageFiles, unusedImageFiles, unusedFontSlots }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, layouts, collections, fonts, images, cardsKey])
+}

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -6,8 +6,8 @@ import { invalidateFontCache } from './useFontStyles'
 // Remote backends get 5min staleTime (mutations invalidate immediately anyway).
 // Local backends get Infinity (only invalidate on mutation).
 const isRemote = () => ['s3', 'googleDrive'].includes(getProvider())
-const staleTime = () => isRemote() ? 5 * 60_000 : Infinity
-const gcTime = () => isRemote() ? 10 * 60_000 : Infinity
+export const staleTime = () => isRemote() ? 5 * 60_000 : Infinity
+export const gcTime = () => isRemote() ? 10 * 60_000 : Infinity
 
 // ── Query keys ──────────────────────────────────────────────────────
 export const queryKeys = {

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -28,6 +28,7 @@ import {
 } from '../hooks/useGameData'
 import FilesPanel from '@/components/FilesPanel'
 import useAssetUrl from '../hooks/useAssetUrl'
+import useAssetUsage from '../hooks/useAssetUsage'
 import useFontStyles from '../hooks/useFontStyles'
 const LazyImageEditor = lazy(() => import('@/components/ImageEditor'))
 
@@ -150,6 +151,7 @@ export default function CollectionsPage() {
   const [selectedImage, setSelectedImage_] = useState<string | null>(() => { try { return localStorage.getItem(`game:${gameId}:selectedImage`) } catch { return null } })
   const setSelectedImage = (v: string | null) => { setSelectedImage_(v); try { if (v) localStorage.setItem(`game:${gameId}:selectedImage`, v); else localStorage.removeItem(`game:${gameId}:selectedImage`) } catch {} }
   const [showImageUpload, setShowImageUpload] = useState(false)
+  const [showUnusedImagesOnly, setShowUnusedImagesOnly] = useState(false)
   const [showCreateCollection, setShowCreateCollection] = useState(false)
   const [newCollectionName, setNewCollectionName] = useState('')
   const [newCollectionLayout, setNewCollectionLayout] = useState('')
@@ -180,6 +182,23 @@ export default function CollectionsPage() {
   const [layoutPreviewCards, setLayoutPreviewCards] = useState<any[]>([])
 
   const selectedLayout = selectedLayoutId ? layouts.find(t => t.id === selectedLayoutId) : null
+
+  // Unused-asset detection (scans all layouts, collections and cards)
+  const { isLoading: usageLoading, unusedImageFiles, unusedFontSlots } = useAssetUsage(gameId)
+  const unusedImages = usageLoading ? [] : gameImages.filter(img => unusedImageFiles.has(img.file))
+
+  const handleDeleteUnusedImages = async () => {
+    if (!unusedImages.length) return
+    setStatus(`Deleting ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'}...`)
+    try {
+      for (const img of unusedImages) await deleteImageMut.mutateAsync(img.file)
+      if (selectedImage && unusedImageFiles.has(selectedImage)) setSelectedImage(null)
+      setShowUnusedImagesOnly(false)
+      setStatus(`Deleted ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'}.`)
+    } catch {
+      setStatus('Error deleting unused images.')
+    }
+  }
 
   // Auto-select first collection when data loads
   useEffect(() => {
@@ -707,6 +726,7 @@ export default function CollectionsPage() {
                 selectedFont={selectedFont}
                 onSelectFont={setSelectedFont}
                 isLoading={fontsLoading}
+                unusedSlots={usageLoading ? undefined : unusedFontSlots}
               />
 
               <FontPreviewEditor previewText={fontPreviewText} onChangePreviewText={setFontPreviewText} />
@@ -750,7 +770,7 @@ export default function CollectionsPage() {
             })() : (
               <FilterableList
                 title="Images"
-                items={gameImages}
+                items={showUnusedImagesOnly ? unusedImages : gameImages}
                 getKey={img => img.file}
                 getName={img => img.name}
                 viewMode={{ key: `game:${gameId}:imageViewMode`, default: 'gallery' }}
@@ -764,7 +784,10 @@ export default function CollectionsPage() {
                 }}
                 empty={imagesLoading
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
-                  : <p className="text-sm text-muted-foreground">No images yet.</p>}
+                  : <p className="text-sm text-muted-foreground">{showUnusedImagesOnly ? 'No unused images.' : 'No images yet.'}</p>}
+                subheader={showUnusedImagesOnly ? (
+                  <span className="text-xs text-muted-foreground">Not referenced by any layout, card or collection. Checkpoints are not scanned.</span>
+                ) : undefined}
                 actions={selectedImage ? (<>
                   <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" title="Edit image"
                     onClick={() => setEditingImage(true)}>
@@ -785,11 +808,28 @@ export default function CollectionsPage() {
                     } catch { setStatus('Error deleting image.') }
                   }} />
                 </>) : undefined}
-                toolbar={
+                toolbar={<>
+                  {(unusedImages.length > 0 || showUnusedImagesOnly) && (
+                    <Button
+                      size="sm"
+                      variant={showUnusedImagesOnly ? 'secondary' : 'ghost'}
+                      onClick={() => setShowUnusedImagesOnly(v => !v)}
+                      title={showUnusedImagesOnly ? 'Show all images' : 'Show only unused images'}
+                    >
+                      {unusedImages.length} unused
+                    </Button>
+                  )}
+                  {unusedImages.length > 0 && (
+                    <ConfirmButton
+                      variant="ghost"
+                      title={`Delete ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'} (checkpoints are not scanned)`}
+                      onConfirm={handleDeleteUnusedImages}
+                    />
+                  )}
                   <Button size="sm" variant="ghost" onClick={() => setShowImageUpload(v => !v)} title={showImageUpload ? 'Cancel' : 'Upload image'}>
                     <Plus className={`h-4 w-4 transition-transform ${showImageUpload ? 'rotate-45' : ''}`} />
                   </Button>
-                }
+                </>}
                 drawer={showImageUpload ? (
                   <div className="px-3 py-2 border-b">
                     <ValueItemEditor
@@ -800,23 +840,30 @@ export default function CollectionsPage() {
                     />
                   </div>
                 ) : undefined}
-                renderItem={(img, vm, selected) => vm === 'gallery' ? (
-                  <CardThumbnail
-                    src={img.url} name={img.name} aspectRatio="1"
-                    selected={selected}
-                  />
-                ) : (
-                  <ListItem selected={selected}>
-                    <div className={vm === 'detailed' ? 'flex items-center gap-3' : ''}>
-                      {vm === 'detailed' && (
-                        <div className="h-10 w-10 shrink-0 rounded border overflow-hidden" style={{ backgroundImage: 'repeating-conic-gradient(#e5e5e5 0% 25%, transparent 0% 50%)', backgroundSize: '8px 8px' }}>
-                          <LoadingImg src={img.url} alt={img.name} className="w-full h-full object-contain" wrapperClassName="w-full h-full" />
-                        </div>
-                      )}
-                      <span className="text-sm font-medium truncate">{img.name}</span>
-                    </div>
-                  </ListItem>
-                )}
+                renderItem={(img, vm, selected) => {
+                  const unusedBadge = !usageLoading && unusedImageFiles.has(img.file) ? (
+                    <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">unused</span>
+                  ) : undefined
+                  return vm === 'gallery' ? (
+                    <CardThumbnail
+                      src={img.url} name={img.name} aspectRatio="1"
+                      selected={selected}
+                      badge={unusedBadge}
+                    />
+                  ) : (
+                    <ListItem selected={selected}>
+                      <div className={vm === 'detailed' ? 'flex items-center gap-3' : 'flex items-center gap-2'}>
+                        {vm === 'detailed' && (
+                          <div className="h-10 w-10 shrink-0 rounded border overflow-hidden" style={{ backgroundImage: 'repeating-conic-gradient(#e5e5e5 0% 25%, transparent 0% 50%)', backgroundSize: '8px 8px' }}>
+                            <LoadingImg src={img.url} alt={img.name} className="w-full h-full object-contain" wrapperClassName="w-full h-full" />
+                          </div>
+                        )}
+                        <span className="text-sm font-medium truncate">{img.name}</span>
+                        {unusedBadge}
+                      </div>
+                    </ListItem>
+                  )
+                }}
               />
             )}
           </TabsContent>

--- a/test/assetUsage.test.js
+++ b/test/assetUsage.test.js
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  collectUsedImageFiles,
+  collectUsedFontSlots,
+  findUnusedFontSlots,
+} from "../src/assetUsage.ts";
+
+const img = (file) => `/api/games/g1/images/${file}`;
+
+const layoutWith = (overrides = {}) => ({
+  version: 2,
+  id: "l1",
+  name: "Layout",
+  width: 63,
+  height: 88,
+  radius: 3,
+  bleed: 0,
+  root: { id: "root", name: "Root", layout: "column", sizePct: 100, gap: 0, children: [], items: [] },
+  ...overrides,
+});
+
+// ── Images ──────────────────────────────────────────────────────────
+
+test("image in layout item defaultValue is used", () => {
+  const layout = layoutWith();
+  layout.root.items.push({ id: "i1", type: "image", defaultValue: img("a.png") });
+  const used = collectUsedImageFiles([layout], [], []);
+  assert.deepEqual([...used], ["a.png"]);
+});
+
+test("image in nested section item is used", () => {
+  const layout = layoutWith();
+  layout.root.children.push({
+    id: "s1", name: "Sub", layout: "row", sizePct: 50, gap: 0,
+    children: [{
+      id: "s2", name: "Deep", layout: "row", sizePct: 50, gap: 0, children: [],
+      items: [{ id: "i2", type: "image", defaultValue: img("deep.png") }],
+    }],
+    items: [],
+  });
+  const used = collectUsedImageFiles([layout], [], []);
+  assert.ok(used.has("deep.png"));
+});
+
+test("image in card field value is used, including multiple URLs in one value", () => {
+  const card = { id: "c1", name: "Card", fields: { art: img("b.png"), text: `see ${img("c.png")} and ${img("d.png")}` } };
+  const used = collectUsedImageFiles([], [], [card]);
+  assert.deepEqual([...used].sort(), ["b.png", "c.png", "d.png"]);
+});
+
+test("image in bindingMeta default and values is used", () => {
+  const layout = layoutWith({
+    bindingMeta: {
+      "defaultValue:art": { default: img("def.png"), values: [img("v1.png"), img("v2.png")] },
+    },
+  });
+  const used = collectUsedImageFiles([layout], [], []);
+  assert.deepEqual([...used].sort(), ["def.png", "v1.png", "v2.png"]);
+});
+
+test("image in collection back is used", () => {
+  const used = collectUsedImageFiles([], [{ id: "col1", back: img("back.png") }], []);
+  assert.ok(used.has("back.png"));
+});
+
+test("unreferenced images are not collected and URL matching is game-id-agnostic", () => {
+  const card = { id: "c1", fields: { art: "/api/games/other-game/images/x.png" } };
+  const used = collectUsedImageFiles([], [], [card]);
+  assert.ok(used.has("x.png"));
+  assert.equal(used.size, 1);
+});
+
+test("image URL stops at quote/whitespace/markup delimiters", () => {
+  const card = { id: "c1", fields: { t: `<img src="${img("q.png")}"> trailing` } };
+  const used = collectUsedImageFiles([], [], [card]);
+  assert.deepEqual([...used], ["q.png"]);
+});
+
+// ── Fonts ───────────────────────────────────────────────────────────
+
+const FONTS = {
+  title: { name: "Title Font", file: "aaa.woff2", source: "upload" },
+  body: { name: "Body Font", file: "bbb.woff2", source: "upload" },
+  fancy: { name: "Fancy Font", file: "ccc.woff2", source: "google" },
+};
+
+test("first font slot is always used (renderer fallback)", () => {
+  const used = collectUsedFontSlots(FONTS, [], []);
+  assert.ok(used.has("title"));
+  assert.equal(used.size, 1);
+});
+
+test("static item.font marks slot used", () => {
+  const layout = layoutWith();
+  layout.root.items.push({ id: "t1", type: "text", font: "fancy" });
+  const used = collectUsedFontSlots(FONTS, [layout], []);
+  assert.ok(used.has("fancy"));
+  assert.ok(!used.has("body"));
+});
+
+test("font bindingMeta default and values mark slots used", () => {
+  const layout = layoutWith({
+    bindingMeta: { "font:style": { default: "body", values: ["fancy"] } },
+  });
+  const used = collectUsedFontSlots(FONTS, [layout], []);
+  assert.ok(used.has("body"));
+  assert.ok(used.has("fancy"));
+});
+
+test("card field values only count for fields bound to font", () => {
+  const layout = layoutWith();
+  layout.root.items.push({ id: "t1", type: "text", bindings: { font: { field: "style" } } });
+  const cards = [
+    { id: "c1", fields: { style: "fancy" } },
+    // "body" appears in an unbound field: must NOT count as a font reference
+    { id: "c2", fields: { flavor: "body" } },
+  ];
+  const used = collectUsedFontSlots(FONTS, [layout], cards);
+  assert.ok(used.has("fancy"));
+  assert.ok(!used.has("body"));
+});
+
+test("scoped card field key (font:field) counts as a font reference", () => {
+  const layout = layoutWith();
+  layout.root.items.push({ id: "t1", type: "text", bindings: { font: { field: "style" } } });
+  const cards = [{ id: "c1", fields: { "font:style": "body" } }];
+  const used = collectUsedFontSlots(FONTS, [layout], cards);
+  assert.ok(used.has("body"));
+});
+
+test("empty font manifest yields no used slots", () => {
+  assert.equal(collectUsedFontSlots({}, [], []).size, 0);
+});
+
+test("findUnusedFontSlots excludes used slots and slots sharing a file with a used slot", () => {
+  const fonts = {
+    a: { name: "A", file: "shared.woff2", source: "upload" },
+    b: { name: "B", file: "shared.woff2", source: "upload" },
+    c: { name: "C", file: "solo.woff2", source: "upload" },
+  };
+  // "a" is used; "b" shares its file, so deleting "b" would also delete "a"
+  const unused = findUnusedFontSlots(fonts, new Set(["a"]));
+  assert.deepEqual(unused, ["c"]);
+});


### PR DESCRIPTION
## Summary

Lets you see which uploaded images and fonts are not referenced anywhere in a game, and delete them — individually or in bulk.

- **Images tab**: unused images get an amber "unused" badge in every view mode, a toolbar chip (`N unused`) filters the list to unused-only, and a confirm-guarded trash button deletes all unused images at once.
- **Fonts tab**: unused fonts get the same badge, and a `N unused` confirm-guarded button bulk-deletes them.

## How "unused" is decided

New `src/assetUsage.ts` scans **all layouts, collections and cards** of the game:

- **Images** are referenced by full `/api/games/{id}/images/{file}` URLs. The scanner checks image-item `defaultValue`s (recursing through sections), layout `bindingMeta` defaults and allowed values, every card field value (bound columns can carry image URLs), and collection `back`s — the same sites the zip exporter uses. `gameZip.ts` now imports this shared collector instead of keeping its own copy, so export and unused-detection can't drift.
- **Fonts** are referenced by manifest slot key: static `item.font`, `bindingMeta` for `font:*` bindings, and card fields that some item actually binds its font property to (both plain and `font:`-scoped keys). Two safety rules avoid false positives:
  - the **first manifest slot** is always considered used — both renderers fall back to it whenever a text item has no valid font;
  - a slot sharing its font **file** with a used slot is never flagged, because `deleteFont` removes every slot pointing at the same file.

Checkpoint snapshots aren't readable through the storage interface, so they are **not scanned**; the UI states this next to the filter and in the delete tooltips.

## Other changes

- `useAssetUsage` hook loads all card lists via `useQueries` (shares the existing query cache/invalidation) and memoizes the scan.
- `ConfirmButton` gains optional `title`/`label` props for the bulk-delete buttons.
- `staleTime`/`gcTime` helpers exported from `useGameData`.

## Testing

- New `test/assetUsage.test.js`: 14 unit tests covering every image reference site, delimiter/multi-URL parsing, the font fallback slot, bound-field-only font detection, scoped field keys, and shared-file protection.
- Full suite: 197/197 pass. `tsc` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9tHhGmWqQqk6DppXdY6VN

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9tHhGmWqQqk6DppXdY6VN)_