### PR TITLE
Include checkpoint snapshots in unused-asset detection

### DIFF
--- a/src/assetUsage.ts
+++ b/src/assetUsage.ts
@@ -9,9 +9,9 @@
  * - Fonts are referenced by manifest slot key (`item.font`, font bindings,
  *   bindingMeta for `font:*`), never by URL.
  *
- * Checkpoints are self-contained snapshots whose contents are not readable
- * through the storage interface, so they are NOT scanned — callers should
- * surface that caveat when offering deletion.
+ * Checkpoint snapshots also keep assets alive: callers should feed each
+ * checkpoint's cards and collection snapshot (getCheckpoint) into the
+ * collectors alongside the live data, as useAssetUsage does.
  */
 
 // Matches all occurrences in a value (rich text can embed several images)

--- a/src/components/FontManager.tsx
+++ b/src/components/FontManager.tsx
@@ -151,7 +151,7 @@ export default function FontManager({ gameId, fonts, onFontsChange, onStatus, sh
               variant="ghost"
               disabled={loading}
               label={`${unusedCount} unused`}
-              title={`Delete ${unusedCount} unused font${unusedCount === 1 ? '' : 's'} (checkpoints are not scanned)`}
+              title={`Delete ${unusedCount} unused font${unusedCount === 1 ? '' : 's'}`}
               onConfirm={handleDeleteUnused}
             />
           )}

--- a/src/hooks/useAssetUsage.ts
+++ b/src/hooks/useAssetUsage.ts
@@ -7,7 +7,7 @@ import { collectUsedImageFiles, collectUsedFontSlots, findUnusedFontSlots } from
 export type AssetUsage = {
   /** True while any of the underlying game data is still loading. */
   isLoading: boolean
-  /** Image file names referenced by at least one layout, card or collection. */
+  /** Image file names referenced by at least one layout, card, collection or checkpoint. */
   usedImageFiles: Set<string>
   /** Image file names present in storage but referenced nowhere. */
   unusedImageFiles: Set<string>
@@ -16,10 +16,9 @@ export type AssetUsage = {
 }
 
 /**
- * Scans the whole game (all layouts, all collections, all cards) for asset
- * references and reports which uploaded images and fonts are unused.
- * Checkpoint snapshots cannot be read through the storage interface and are
- * not scanned.
+ * Scans the whole game (all layouts, all collections, all cards, and all
+ * checkpoint snapshots) for asset references and reports which uploaded
+ * images and fonts are unused.
  */
 export default function useAssetUsage(gameId: string | undefined): AssetUsage {
   const storage = useStorageInstance()!
@@ -38,12 +37,50 @@ export default function useAssetUsage(gameId: string | undefined): AssetUsage {
     })),
   })
 
-  const isLoading = layoutsLoading || collectionsLoading || fontsLoading || imagesLoading
+  const checkpointListQueries = useQueries({
+    queries: collections.map((col: any) => ({
+      queryKey: queryKeys.checkpoints(gameId!, col.id),
+      queryFn: () => storage.listCheckpoints(gameId!, col.id),
+      enabled: !!storage && !!gameId,
+      staleTime: staleTime(),
+      gcTime: gcTime(),
+    })),
+  })
+
+  const checkpointRefs = collections.flatMap((col: any, i: number) =>
+    ((checkpointListQueries[i]?.data as any[]) ?? []).map((cp: any) => ({
+      collectionId: col.id as string,
+      checkpointId: cp.id as string,
+    })),
+  )
+
+  const checkpointQueries = useQueries({
+    queries: checkpointRefs.map((ref) => ({
+      queryKey: queryKeys.checkpoint(gameId!, ref.collectionId, ref.checkpointId),
+      queryFn: () => storage.getCheckpoint(gameId!, ref.collectionId, ref.checkpointId),
+      enabled: !!storage && !!gameId,
+      // Checkpoint contents are immutable once created
+      staleTime: Infinity,
+      gcTime: gcTime(),
+    })),
+  })
+
+  // An errored query would silently drop its references and could flag a
+  // used asset as unused, so a failed scan reports nothing instead.
+  const hasError = cardQueries.some((q) => q.isError)
+    || checkpointListQueries.some((q) => q.isError)
+    || checkpointQueries.some((q) => q.isError)
+
+  const isLoading = hasError
+    || layoutsLoading || collectionsLoading || fontsLoading || imagesLoading
     || cardQueries.some((q) => q.isLoading)
+    || checkpointListQueries.some((q) => q.isLoading)
+    || checkpointQueries.some((q) => q.isLoading)
 
   // useQueries returns a fresh array every render; key the memo on the data
   // update timestamps so the scan only reruns when something actually changed.
   const cardsKey = cardQueries.map((q) => q.dataUpdatedAt).join(',')
+  const checkpointsKey = checkpointQueries.map((q) => q.dataUpdatedAt).join(',')
 
   return useMemo(() => {
     const empty = {
@@ -54,8 +91,15 @@ export default function useAssetUsage(gameId: string | undefined): AssetUsage {
     }
     if (isLoading) return empty
 
-    const allCards = cardQueries.flatMap((q) => (q.data as any[]) ?? [])
-    const usedImageFiles = collectUsedImageFiles(layouts, collections, allCards)
+    const checkpoints = checkpointQueries.map((q) => q.data as any).filter(Boolean)
+    const allCards = [
+      ...cardQueries.flatMap((q) => (q.data as any[]) ?? []),
+      ...checkpoints.flatMap((cp) => cp.cards ?? []),
+    ]
+    // A checkpoint's collection snapshot carries its own `back` image
+    const allCollections = [...collections, ...checkpoints.map((cp) => cp.collection).filter(Boolean)]
+
+    const usedImageFiles = collectUsedImageFiles(layouts, allCollections, allCards)
     const unusedImageFiles = new Set(
       images.map((img) => img.file).filter((file) => !usedImageFiles.has(file)),
     )
@@ -63,5 +107,5 @@ export default function useAssetUsage(gameId: string | undefined): AssetUsage {
     const unusedFontSlots = new Set(findUnusedFontSlots(fonts, usedFontSlots))
     return { isLoading, usedImageFiles, unusedImageFiles, unusedFontSlots }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, layouts, collections, fonts, images, cardsKey])
+  }, [isLoading, layouts, collections, fonts, images, cardsKey, checkpointsKey])
 }

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
   fonts: (gameId: string) => ['fonts', gameId] as const,
   images: (gameId: string) => ['images', gameId] as const,
   checkpoints: (gameId: string, collectionId: string) => ['checkpoints', gameId, collectionId] as const,
+  checkpoint: (gameId: string, collectionId: string, checkpointId: string) => ['checkpoint', gameId, collectionId, checkpointId] as const,
 }
 
 // ── Query hooks ─────────────────────────────────────────────────────

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -766,7 +766,7 @@ export default function CollectionsPage() {
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                   : <p className="text-sm text-muted-foreground">{showUnusedImagesOnly ? 'No unused images.' : 'No images yet.'}</p>}
                 subheader={showUnusedImagesOnly ? (
-                  <span className="text-xs text-muted-foreground">Not referenced by any layout, card or collection. Checkpoints are not scanned.</span>
+                  <span className="text-xs text-muted-foreground">Not referenced by any layout, card, collection or checkpoint.</span>
                 ) : undefined}
                 actions={selectedImage ? (<>
                   <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" title="Edit image"
@@ -802,7 +802,7 @@ export default function CollectionsPage() {
                   {unusedImages.length > 0 && (
                     <ConfirmButton
                       variant="ghost"
-                      title={`Delete ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'} (checkpoints are not scanned)`}
+                      title={`Delete ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'}`}
                       onConfirm={handleDeleteUnusedImages}
                     />
                   )}

--- a/src/server.ts
+++ b/src/server.ts
@@ -575,6 +575,13 @@ app.get("/api/games/:gameId/collections/:collectionId/checkpoints", (req, res) =
   res.json(metas);
 });
 
+app.get("/api/games/:gameId/collections/:collectionId/checkpoints/:checkpointId", (req, res) => {
+  const { gameId, collectionId, checkpointId } = req.params;
+  const checkpoint = readJson<any>(checkpointPath(gameId, collectionId, checkpointId), null);
+  if (!checkpoint) return res.status(404).json({ error: "Checkpoint not found" });
+  res.json(checkpoint);
+});
+
 app.post("/api/games/:gameId/collections/:collectionId/checkpoints", (req, res) => {
   const { gameId, collectionId } = req.params;
   const name = req.body?.name?.trim() || "Checkpoint";

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -88,6 +88,7 @@ export interface StorageBackend {
   // Named, restorable snapshots of a collection (its cards + metadata).
   // Each is stored as one self-contained document under the collection.
   listCheckpoints(gameId: string, collectionId: string): Promise<CheckpointMeta[]>;
+  getCheckpoint(gameId: string, collectionId: string, checkpointId: string): Promise<Checkpoint>;
   createCheckpoint(gameId: string, collectionId: string, name: string): Promise<CheckpointMeta>;
   restoreCheckpoint(gameId: string, collectionId: string, checkpointId: string): Promise<void>;
   deleteCheckpoint(gameId: string, collectionId: string, checkpointId: string): Promise<void>;

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -722,6 +722,14 @@ export const createGoogleDriveStorage = (options = {}) => {
     return metas;
   };
 
+  const getCheckpoint = async (gameId, collectionId, checkpointId) => {
+    const key = `chkfile:${gameId}:${collectionId}:${checkpointId}`;
+    const fid = fileIds.get(key) ?? await findFile(`${checkpointId}.json`, await checkpointsFolder(gameId, collectionId));
+    if (!fid) throw new Error("Checkpoint not found.");
+    fileIds.set(key, fid);
+    return await readFile(fid);
+  };
+
   const createCheckpoint = async (gameId, collectionId, name) => {
     const col = await getCollection(gameId, collectionId);
     const cards = await listCards(gameId, collectionId);
@@ -771,7 +779,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     listCards, getCard, saveCard, deleteCard, copyCard,
     listFonts, addGoogleFont, uploadFont, deleteFont, renameFont,
     uploadImage, listImages, deleteImage, renameImage,
-    listCheckpoints, createCheckpoint, restoreCheckpoint, deleteCheckpoint,
+    listCheckpoints, getCheckpoint, createCheckpoint, restoreCheckpoint, deleteCheckpoint,
     clearCache,
   };
 };

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -531,6 +531,17 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
       }
     },
 
+    async getCheckpoint(gameId, collectionId, checkpointId) {
+      const db = await openDB();
+      try {
+        const checkpoint = await idbGet(db, "checkpoints", [gameId, collectionId, checkpointId]);
+        if (!checkpoint) throw new Error(`Checkpoint not found: ${checkpointId}`);
+        return checkpoint;
+      } finally {
+        db.close();
+      }
+    },
+
     async createCheckpoint(gameId, collectionId, name) {
       const db = await openDB();
       try {

--- a/src/storage/localFile.js
+++ b/src/storage/localFile.js
@@ -278,6 +278,12 @@ export const createLocalFileStorage = ({ defaultLayout }) => {
       return await response.json();
     },
 
+    async getCheckpoint(gameId, collectionId, checkpointId) {
+      const response = await fetch(`${apiBase}/games/${gameId}/collections/${collectionId}/checkpoints/${checkpointId}`);
+      if (!response.ok) throw new Error("Failed to get checkpoint");
+      return await response.json();
+    },
+
     async createCheckpoint(gameId, collectionId, name) {
       const response = await fetch(`${apiBase}/games/${gameId}/collections/${collectionId}/checkpoints`, {
         method: "POST",

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -653,6 +653,10 @@ export const createS3Storage = (options = {}) => {
       return metas;
     },
 
+    async getCheckpoint(gameId, collectionId, checkpointId) {
+      return await getJson(checkpointKey(gameId, collectionId, checkpointId));
+    },
+
     async createCheckpoint(gameId, collectionId, name) {
       const col = await getJson(collectionKey(gameId, collectionId));
       const cardKeys = await listKeys(cardsPrefix(gameId, collectionId));

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -255,6 +255,11 @@ async function startServer() {
       .map(cp => ({ id: cp.id, name: cp.name, createdAt: cp.createdAt }))
       .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)));
   });
+  app.get("/api/games/:gid/collections/:cid/checkpoints/:chk", (c) => {
+    const checkpoint = readJson(chkPath(c.req.param("gid"), c.req.param("cid"), c.req.param("chk")), null);
+    if (!checkpoint) return c.json({ error: "Checkpoint not found" }, 404);
+    return c.json(checkpoint);
+  });
   app.post("/api/games/:gid/collections/:cid/checkpoints", async (c) => {
     const gid = c.req.param("gid"), cid = c.req.param("cid");
     const col = readJson(colPath(gid, cid), null);
@@ -918,6 +923,15 @@ function checkpointSuite(name, makeStorage) {
     const list = await s.listCheckpoints(game.id, colId);
     assert.equal(list.length, 1, "one checkpoint listed");
     assert.equal(list[0].name, "v1");
+
+    // Full contents are readable without restoring (used by unused-asset scan).
+    const full = await s.getCheckpoint(game.id, colId, cp.id);
+    assert.equal(full.id, cp.id);
+    assert.equal(full.name, "v1");
+    assert.deepEqual(full.cards.map((c) => c.id).sort(), ["c1", "c2"], "checkpoint contents include the snapshotted cards");
+    assert.equal(full.cards.find((c) => c.id === "c2").fields.hp, "2");
+    assert.equal(full.collection.layoutId, "default", "collection snapshot included");
+    await assert.rejects(() => s.getCheckpoint(game.id, colId, "nope"), "missing checkpoint rejects");
 
     // Mutate after the checkpoint: delete c1, edit c2, add c3.
     await s.deleteCard(game.id, colId, "c1");

--- a/test/storageCaching.test.js
+++ b/test/storageCaching.test.js
@@ -438,6 +438,12 @@ test("googleDrive: checkpoint captures cards + layout and restore reverts change
   assert.ok(cp.id && cp.name === "v1" && cp.createdAt);
   assert.equal((await storage.listCheckpoints(game.id, "default")).length, 1);
 
+  // Full contents are readable without restoring (used by unused-asset scan).
+  const full = await storage.getCheckpoint(game.id, "default", cp.id);
+  assert.equal(full.id, cp.id);
+  assert.deepEqual(full.cards.map((c) => c.id).sort(), ["c1", "c2"]);
+  assert.ok(full.collection.layoutId, "collection snapshot included");
+
   await storage.deleteCard(game.id, "default", "c1");
   await storage.saveCard(game.id, "default", "c2", { id: "c2", name: "Beta EDITED", fields: { hp: "99" } });
   await storage.saveCard(game.id, "default", "c3", { id: "c3", name: "Gamma", fields: {} });


### PR DESCRIPTION
## Summary

Follow-up to #64. Checkpoints embed a full copy of a collection's cards and back image, so an asset referenced **only** by a checkpoint was flagged unused and could be deleted — breaking a later restore. Checkpoint contents now count as references, and the "checkpoints are not scanned" caveats are gone.

## Changes

- **`getCheckpoint(gameId, collectionId, checkpointId)`** added to the `StorageBackend` contract and all four backends:
  - `localFile` — new `GET /api/games/:gameId/collections/:collectionId/checkpoints/:checkpointId` endpoint in `server.ts` (covered by the existing decoded-segment traversal guard)
  - `indexedDB` — direct store read
  - `s3` — `getJson` on the checkpoint key
  - `googleDrive` — file lookup with id-cache warm-up
- **`useAssetUsage`** lists each collection's checkpoints, fetches their contents via `useQueries` (`staleTime: Infinity` — snapshots are immutable once created), and feeds checkpoint cards + the snapshot's collection `back` into the image and font scans.
- **Fail-safe**: if any card or checkpoint fetch errors, the scan reports *nothing* instead of risking a false "unused" flag on an asset whose references it couldn't see.
- UI text updated: filter subheader now reads "Not referenced by any layout, card, collection or checkpoint"; delete tooltips drop the caveat.

## Testing

- `checkpointSuite` (localFile, indexedDB, s3) now verifies `getCheckpoint` returns full contents (cards + collection snapshot) without restoring, and rejects for missing ids; the googleDrive checkpoint test in `storageCaching.test.js` gets the same assertions. The test-side mock server gained the matching GET route.
- Full suite: 197/197 pass. `tsc` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9tHhGmWqQqk6DppXdY6VN

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9tHhGmWqQqk6DppXdY6VN)_