### PR TITLE
Card backs: layout-only, edited inline like the front

### DIFF
--- a/src/assetUsage.ts
+++ b/src/assetUsage.ts
@@ -4,8 +4,8 @@
  *
  * Reference forms differ by asset type:
  * - Images are referenced by full URL (`/api/games/{gameId}/images/{file}`)
- *   in card field values, image item defaultValues, layout bindingMeta
- *   defaults/values, and collection backs.
+ *   in card field values, image item defaultValues, and layout bindingMeta
+ *   defaults/values.
  * - Fonts are referenced by manifest slot key (`item.font`, font bindings,
  *   bindingMeta for `font:*`), never by URL.
  *
@@ -27,10 +27,9 @@ const walkItems = (section: SectionLike | undefined | null, fn: (item: any) => v
   for (const child of section.children ?? []) walkItems(child, fn)
 }
 
-/** Image file names referenced anywhere in the given layouts, collections and cards. */
+/** Image file names referenced anywhere in the given layouts and cards. */
 export function collectUsedImageFiles(
   layouts: any[],
-  collections: any[],
   allCards: any[],
 ): Set<string> {
   const files = new Set<string>()
@@ -50,7 +49,6 @@ export function collectUsedImageFiles(
       for (const v of meta?.values ?? []) collect(v)
     }
   }
-  for (const col of collections) collect(col.back)
   return files
 }
 

--- a/src/components/FilesPanel.tsx
+++ b/src/components/FilesPanel.tsx
@@ -20,7 +20,7 @@ const svgToImage = (svg: string): Promise<HTMLImageElement> =>
     img.src = `data:image/svg+xml,${encodeURIComponent(svg)}`
   })
 
-export type FileCard = CardData & { collectionId?: string; collectionName?: string; collectionBack?: string; collectionBackFit?: string; collectionBackLayoutId?: string }
+export type FileCard = CardData & { collectionId?: string; collectionName?: string; collectionBackLayoutId?: string }
 
 type FilesPanelProps = {
   gameId: string
@@ -31,8 +31,6 @@ type FilesPanelProps = {
   layout?: CardLayout
   gameFonts?: Record<string, { name: string; file: string }>
   storage?: any
-  back?: string
-  backFit?: "cover" | "contain" | "fill"
   backLayoutId?: string
   allLayouts?: CardLayout[]
   onStatusChange?: (msg: string) => void
@@ -42,7 +40,7 @@ type FilesPanelProps = {
 export default function FilesPanel({
   gameId, collectionId, gameName, collectionName,
   cards, layout, gameFonts,
-  back, backFit, backLayoutId, allLayouts,
+  backLayoutId, allLayouts,
   onStatusChange,
 }: FilesPanelProps) {
   const navigate = useNavigate()
@@ -118,15 +116,15 @@ export default function FilesPanel({
         if (!resp.ok) throw new Error(`Upload failed: ${resp.status}`)
       }
 
-      type DeckGroup = { name: string; cards: FileCard[]; back?: string; backFit?: string; backLayoutId?: string }
+      type DeckGroup = { name: string; cards: FileCard[]; backLayoutId?: string }
       let groups: DeckGroup[]
       if (collectionId) {
-        groups = [{ name: collectionName || 'deck', cards: selected, back, backFit, backLayoutId }]
+        groups = [{ name: collectionName || 'deck', cards: selected, backLayoutId }]
       } else {
         const byCol = new Map<string, DeckGroup>()
         for (const card of selected) {
           const key = card.collectionName || 'deck'
-          if (!byCol.has(key)) byCol.set(key, { name: key, cards: [], back: card.collectionBack, backFit: card.collectionBackFit, backLayoutId: card.collectionBackLayoutId })
+          if (!byCol.has(key)) byCol.set(key, { name: key, cards: [], backLayoutId: card.collectionBackLayoutId })
           byCol.get(key)!.cards.push(card)
         }
         groups = [...byCol.values()]
@@ -193,28 +191,6 @@ export default function FilesPanel({
             svg = await embedImagesInSvg(svg)
             const backImg = await svgToImage(svg)
             backCtx.drawImage(backImg, 0, 0, cardW, cardH)
-          } catch {
-            backCtx.fillStyle = '#1b1a17'
-            backCtx.fillRect(0, 0, cardW, cardH)
-          }
-        } else if (group.back) {
-          try {
-            const resp = await fetch(group.back)
-            const backImg = await createImageBitmap(await resp.blob())
-            const fit = group.backFit || 'cover'
-            if (fit === 'fill') {
-              backCtx.drawImage(backImg, 0, 0, cardW, cardH)
-            } else if (fit === 'contain') {
-              backCtx.fillStyle = '#ffffff'
-              backCtx.fillRect(0, 0, cardW, cardH)
-              const s = Math.min(cardW / backImg.width, cardH / backImg.height)
-              const w = backImg.width * s, h = backImg.height * s
-              backCtx.drawImage(backImg, (cardW - w) / 2, (cardH - h) / 2, w, h)
-            } else {
-              const s = Math.max(cardW / backImg.width, cardH / backImg.height)
-              const w = backImg.width * s, h = backImg.height * s
-              backCtx.drawImage(backImg, (cardW - w) / 2, (cardH - h) / 2, w, h)
-            }
           } catch {
             backCtx.fillStyle = '#1b1a17'
             backCtx.fillRect(0, 0, cardW, cardH)

--- a/src/components/LayoutPreview.tsx
+++ b/src/components/LayoutPreview.tsx
@@ -12,7 +12,6 @@ type LayoutPreviewProps = {
   layout: CardLayout
   gameId: string
   cards?: PreviewCard[]
-  back?: string
   gameFonts?: Record<string, { name: string; file: string }>
   selectedNodeId?: string | null
   onNodeClick?: (id: string) => void
@@ -56,7 +55,7 @@ function CardPicker({ cards, value, onChange }: { cards: PreviewCard[]; value: s
   )
 }
 
-export default function LayoutPreview({ layout, gameId, cards = [], back, gameFonts, selectedNodeId, onNodeClick }: LayoutPreviewProps) {
+export default function LayoutPreview({ layout, gameId, cards = [], gameFonts, selectedNodeId, onNodeClick }: LayoutPreviewProps) {
   const [showSections, setShowSections] = useState(true)
   const [showItemWires, setShowItemWires] = useState(true)
   const [previewCardId, setPreviewCardId] = useState<string | null>(null)
@@ -94,7 +93,7 @@ export default function LayoutPreview({ layout, gameId, cards = [], back, gameFo
     debounceRef.current = setTimeout(run, 150)
 
     return () => { cancelled.current = true; if (debounceRef.current) clearTimeout(debounceRef.current) }
-  }, [layout, gameId, showSections, showItemWires, selectedNodeId, previewCard, back])
+  }, [layout, gameId, showSections, showItemWires, selectedNodeId, previewCard])
 
   if (!previewUrl) return null
 

--- a/src/components/layout/LayoutEditorPanel.tsx
+++ b/src/components/layout/LayoutEditorPanel.tsx
@@ -15,10 +15,9 @@ type LayoutEditorPanelProps = {
   gameImages?: { file: string; url: string; name: string }[]
   onUploadFile: (file: File) => Promise<string>
   cards?: PreviewCard[]
-  back?: string
 }
 
-export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, gameFonts, gameImages, onUploadFile, cards, back }: LayoutEditorPanelProps) {
+export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, gameFonts, gameImages, onUploadFile, cards }: LayoutEditorPanelProps) {
   // Local working copy for instant feedback; debounced save to backend
   const [workingLayout, setWorkingLayout] = useState(propLayout)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout>>(null)
@@ -220,7 +219,6 @@ export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, 
         layout={layout}
         gameId={gameId}
         cards={cards}
-        back={back}
         gameFonts={gameFonts}
         selectedNodeId={selectedNodeId}
         onNodeClick={handleNodeSelect}

--- a/src/gameZip.ts
+++ b/src/gameZip.ts
@@ -47,7 +47,7 @@ export const exportGameZip = async (
   }
 
   log('Exporting images...')
-  const imageFiles = collectUsedImageFiles(layouts, collections, allCards)
+  const imageFiles = collectUsedImageFiles(layouts, allCards)
 
   for (const file of imageFiles) {
     try {
@@ -161,14 +161,10 @@ export const importGameZip = async (
     log(`Creating collection: ${col.id} (${col.name}) → layout: ${col.layoutId}`)
     const newCol = await storage.createCollection(newGameId, col.name, col.layoutId)
     const newColId = newCol.id
-    // Preserve extra collection fields (backLayoutId, back, backFit, etc.)
+    // Preserve extra collection fields (backLayoutId, etc.)
     // Layout ids are preserved verbatim on import, so backLayoutId needs no remap.
-    const extraFields: Record<string, unknown> = {}
-    if (col.backLayoutId) extraFields.backLayoutId = col.backLayoutId
-    if (col.back) extraFields.back = rewriteAll(col.back)
-    if (col.backFit) extraFields.backFit = col.backFit
-    if (Object.keys(extraFields).length > 0) {
-      await storage.updateCollection(newGameId, newColId, extraFields)
+    if (col.backLayoutId) {
+      await storage.updateCollection(newGameId, newColId, { backLayoutId: col.backLayoutId })
     }
 
     const colDir = f.name.replace('/collection.json', '')

--- a/src/hooks/useAssetUsage.ts
+++ b/src/hooks/useAssetUsage.ts
@@ -7,7 +7,7 @@ import { collectUsedImageFiles, collectUsedFontSlots, findUnusedFontSlots } from
 export type AssetUsage = {
   /** True while any of the underlying game data is still loading. */
   isLoading: boolean
-  /** Image file names referenced by at least one layout, card, collection or checkpoint. */
+  /** Image file names referenced by at least one layout, card or checkpoint. */
   usedImageFiles: Set<string>
   /** Image file names present in storage but referenced nowhere. */
   unusedImageFiles: Set<string>
@@ -96,10 +96,7 @@ export default function useAssetUsage(gameId: string | undefined): AssetUsage {
       ...cardQueries.flatMap((q) => (q.data as any[]) ?? []),
       ...checkpoints.flatMap((cp) => cp.cards ?? []),
     ]
-    // A checkpoint's collection snapshot carries its own `back` image
-    const allCollections = [...collections, ...checkpoints.map((cp) => cp.collection).filter(Boolean)]
-
-    const usedImageFiles = collectUsedImageFiles(layouts, allCollections, allCards)
+    const usedImageFiles = collectUsedImageFiles(layouts, allCards)
     const unusedImageFiles = new Set(
       images.map((img) => img.file).filter((file) => !usedImageFiles.has(file)),
     )

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -58,7 +58,7 @@ function GameFilesPanel({ gameId, game, layouts, collections, gameFonts, onStatu
         const colCards = queryClient.getQueryData<any[]>(queryKeys.cards(gameId, col.id))
           ?? await queryClient.fetchQuery({ queryKey: queryKeys.cards(gameId, col.id), queryFn: () => storage.listCards(gameId, col.id) })
           ?? []
-        cards.push(...colCards.map((c: any) => ({ ...c, collectionId: col.id, collectionName: col.name, collectionBack: col.back, collectionBackFit: col.backFit, collectionBackLayoutId: col.backLayoutId })))
+        cards.push(...colCards.map((c: any) => ({ ...c, collectionId: col.id, collectionName: col.name, collectionBackLayoutId: col.backLayoutId })))
       }
       if (!cancelled) setAllCards(cards)
     }

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft, Copy, Plus, Check, ArrowUpDown, ArrowUp, ArrowDown, ChevronL
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -36,7 +35,7 @@ import PageLayout from '@/components/PageLayout'
 import useStorage from '../hooks/useStorage'
 import {
   useGame, useCollection, useCollections, useLayout, useFonts, useImages, useLayouts, useCards,
-  useUpdateGame, useUpdateCollection, useSaveLayout,
+  useUpdateGame, useUpdateCollection, useCreateLayout, useSaveLayout,
   useCopyCard, useDeleteCard, useTransferCard, useUploadImage,
   useCheckpoints, useCreateCheckpoint, useRestoreCheckpoint, useDeleteCheckpoint,
   useInvalidateGame, queryKeys,
@@ -519,6 +518,7 @@ export default function GameEditorPage() {
   // ── Mutation hooks ──────────────────────────────────────────────
   const updateGameMut = useUpdateGame(gameId)
   const updateCollectionMut = useUpdateCollection(gameId)
+  const createLayoutMut = useCreateLayout(gameId)
   const saveLayoutMut = useSaveLayout(gameId)
   const copyCardMut = useCopyCard(gameId, collectionId)
   const deleteCardMut = useDeleteCard(gameId, collectionId)
@@ -726,7 +726,7 @@ export default function GameEditorPage() {
       }
     }, 100)
     return () => { cancelled = true; clearTimeout(timer) }
-  }, [selectedCard, game?.layout, gameId, collection?.back])
+  }, [selectedCard, game?.layout, gameId])
 
   // Render the card back from its layout (when the collection uses one).
   // The back layout is rendered with the selected card's data so bound
@@ -880,6 +880,18 @@ export default function GameEditorPage() {
   // on onSave, so a fresh function each render would fire spurious duplicate
   // saves — which on slow backends (S3/R2) can interleave and let a stale write
   // overwrite a newer one. Keeping it stable means one save per edit.
+  // Create a fresh layout and assign it as the collection's front or back.
+  const handleCreateAndAssignLayout = async (target: 'front' | 'back') => {
+    if (!gameId || !collectionId) return
+    try {
+      const tpl = await createLayoutMut.mutateAsync(`${collection?.name ?? 'New'} ${target}`)
+      await updateCollectionMut.mutateAsync({
+        collectionId,
+        updates: target === 'front' ? { layoutId: tpl.id } : { backLayoutId: tpl.id },
+      })
+    } catch { setStatus('Error creating layout.') }
+  }
+
   const handleLayoutSave = useCallback((updatedLayout: any) => {
     if (!gameId || !gameRef.current) return
     queryClient.setQueryData(queryKeys.layout(gameId, updatedLayout.id), updatedLayout)
@@ -1069,7 +1081,7 @@ export default function GameEditorPage() {
           <TabsList className="mb-4">
             <TabsTrigger value="cards">Cards</TabsTrigger>
             <TabsTrigger value="data">Data</TabsTrigger>
-            <TabsTrigger value="layout">Layout</TabsTrigger>
+            <TabsTrigger value="layout">Front</TabsTrigger>
             <TabsTrigger value="back">Back</TabsTrigger>
             <TabsTrigger value="import">Import</TabsTrigger>
             <TabsTrigger value="export">Export</TabsTrigger>
@@ -1258,8 +1270,8 @@ export default function GameEditorPage() {
                 <ZoomablePreview
                   src={cardPreview}
                   alt="Card preview"
-                  backImage={resolvedBackLayout ? (backPreview || undefined) : collection?.back}
-                  backFit={resolvedBackLayout ? 'fill' : collection?.backFit}
+                  backImage={backPreview || undefined}
+                  backFit="fill"
                 />
               )}
             </div>
@@ -1289,6 +1301,7 @@ export default function GameEditorPage() {
                     onChange={async (e) => {
                       const newLayoutId = e.target.value
                       if (!gameId || !collectionId || newLayoutId === collection?.layoutId) return
+                      if (newLayoutId === '__new__') { await handleCreateAndAssignLayout('front'); return }
                       try {
                         await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { layoutId: newLayoutId } })
                       } catch {
@@ -1300,6 +1313,7 @@ export default function GameEditorPage() {
                     {allLayouts.map((l: any) => (
                       <option key={l.id} value={l.id}>{l.name}</option>
                     ))}
+                    <option value="__new__">+ New layout…</option>
                   </select>
                 </div>
               )}
@@ -1314,80 +1328,53 @@ export default function GameEditorPage() {
                     return await uploadImageMut.mutateAsync(file)
                   }}
                   cards={cards}
-                  back={collection?.back}
                 />
               )}
             </div>
           </TabsContent>
 
           <TabsContent value="back">
-            {resolvedBackLayout ? (
-              backPreview && <ZoomablePreview src={backPreview} alt="Back preview" maxImgHeight="30vh" />
-            ) : (
-              collection?.back && <ZoomablePreview src={collection.back} alt="Back preview" maxImgHeight="30vh" />
-            )}
-            <Card>
-              <CardContent className="pt-6 space-y-4">
-                <div className="space-y-2">
-                  <Label>Back Layout</Label>
-                  <select
-                    value={collection?.backLayoutId ?? ''}
-                    onChange={async (e) => {
-                      const v = e.target.value
-                      try { await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { backLayoutId: v || null } }) }
-                      catch { setStatus('Error saving back layout.') }
-                    }}
-                    className="w-full rounded-md border bg-background pl-3 pr-8 py-1.5 text-sm"
-                  >
-                    <option value="">None (use image)</option>
-                    {allLayouts.map((l: any) => (
-                      <option key={l.id} value={l.id}>{l.name}</option>
-                    ))}
-                  </select>
-                  <p className="text-xs text-muted-foreground">
-                    {collection?.backLayoutId
-                      ? 'The back is rendered from this layout, like the card front. Edit it from the game\'s layouts page.'
-                      : 'Pick a layout to design the card back, or use a static image below.'}
-                  </p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
+              <div className="px-2 py-1.5">
+                <select
+                  value={collection?.backLayoutId ?? ''}
+                  onChange={async (e) => {
+                    const v = e.target.value
+                    if (!gameId || !collectionId || v === (collection?.backLayoutId ?? '')) return
+                    if (v === '__new__') { await handleCreateAndAssignLayout('back'); return }
+                    try {
+                      await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { backLayoutId: v || null } })
+                    } catch {
+                      setStatus('Error changing back layout.')
+                    }
+                  }}
+                  className="w-full rounded-md border bg-background pl-3 pr-8 py-1.5 text-sm"
+                >
+                  <option value="">No back</option>
+                  {allLayouts.map((l: any) => (
+                    <option key={l.id} value={l.id}>{l.name}</option>
+                  ))}
+                  <option value="__new__">+ New layout…</option>
+                </select>
+              </div>
+              {resolvedBackLayout?.root ? (
+                <LayoutEditorPanel
+                  layout={resolvedBackLayout}
+                  onSave={handleLayoutSave}
+                  gameId={gameId!}
+                  gameFonts={gameFonts}
+                  gameImages={gameImages}
+                  onUploadFile={async (file) => {
+                    return await uploadImageMut.mutateAsync(file)
+                  }}
+                  cards={cards}
+                />
+              ) : (
+                <div className="md:col-span-2 flex items-center justify-center rounded-lg border bg-card p-8">
+                  <p className="text-sm text-muted-foreground">Select or create a back layout to edit</p>
                 </div>
-                {!collection?.backLayoutId && (
-                  <div className="space-y-2">
-                    <Label>Card Back Image</Label>
-                    <ValueItemEditor
-                      property="defaultValue"
-                      itemType="image"
-                      value={collection?.back || ''}
-                      layout={game?.layout}
-                      gameImages={gameImages}
-                      onUploadFile={async (file) => {
-                        return await uploadImageMut.mutateAsync(file)
-                      }}
-                      onChange={async (v) => {
-                        try { await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { back: v || undefined } }) }
-                        catch { setStatus('Error saving back.') }
-                      }}
-                    />
-                  </div>
-                )}
-                {!collection?.backLayoutId && collection?.back && (
-                  <div className="space-y-2">
-                    <FloatingSelect
-                      label="Fit Mode"
-                      value={collection?.backFit || 'cover'}
-                      onValueChange={async (fit) => {
-                        try { await updateCollectionMut.mutateAsync({ collectionId: collectionId!, updates: { backFit: fit } }) }
-                        catch { setStatus('Error saving back fit.') }
-                      }}
-                      options={[
-                        { value: 'cover', label: 'Cover' },
-                        { value: 'contain', label: 'Contain' },
-                        { value: 'fill', label: 'Fill' },
-                      ]}
-                    />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+              )}
+            </div>
           </TabsContent>
 
           <TabsContent value="import">
@@ -1423,8 +1410,6 @@ export default function GameEditorPage() {
               cards={cards}
               layout={game?.layout}
               gameFonts={gameFonts}
-              back={collection?.back}
-              backFit={collection?.backFit}
               backLayoutId={collection?.backLayoutId}
               allLayouts={allLayouts}
               onStatusChange={setStatus}

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -103,7 +103,7 @@ function computePageLayout(config: PrintConfig, cardWidthMm: number, cardHeightM
 
 // --- Component ---
 
-type CardEntry = { card: CardData; layout: CardLayout; collectionName: string; back?: string; backFit?: string; backLayout?: CardLayout }
+type CardEntry = { card: CardData; layout: CardLayout; collectionName: string; backLayout?: CardLayout }
 
 export default function PrintPage() {
   const { gameId, collectionId } = useParams<{ gameId: string; collectionId?: string }>()
@@ -196,7 +196,7 @@ export default function PrintPage() {
           ])
           for (const card of cards) {
             if (cardIdSet && !cardIdSet.has(card.id)) continue
-            all.push({ card, layout: tpl, collectionName: col.name, back: col.back, backFit: col.backFit, backLayout: backTpl ?? undefined })
+            all.push({ card, layout: tpl, collectionName: col.name, backLayout: backTpl ?? undefined })
           }
         }
 
@@ -300,13 +300,11 @@ export default function PrintPage() {
       const isDuplexPdf = config.printMode === 'duplex'
       const foldHPdf = isFoldPdf && (config.foldEdge === 'left' || config.foldEdge === 'right')
 
-      // Resolve a card's back: a layout-rendered SVG (rasterized) wins over
-      // the collection's static back image.
-      const backImageFor = async (idx: number): Promise<{ data: string; type: 'PNG' | 'JPEG' } | null> => {
+      // A card's back is its collection's back layout rendered per card;
+      // cards whose collection has no back layout print nothing on the back.
+      const backImageFor = async (idx: number): Promise<{ data: string; type: 'PNG' } | null> => {
         const bsvg = backSvgs[idx]
-        if (bsvg) return { data: await rasterizeSvg(bsvg, baseCw, baseCh), type: 'PNG' }
-        const back = entries[idx]?.back
-        return back ? { data: back, type: 'JPEG' } : null
+        return bsvg ? { data: await rasterizeSvg(bsvg, baseCw, baseCh), type: 'PNG' } : null
       }
 
       const renderPage = async (startIdx: number, isBack: boolean) => {
@@ -540,27 +538,17 @@ export default function PrintPage() {
                           )}
                         </div>
                       )}
-                      {showBack && (backSvgs[svgIdx] || entry.back) && (
+                      {showBack && backSvgs[svgIdx] && (
                         <div style={config.printMode === 'back' ? { width: '100%', height: '100%' } : backStyle}>
-                          {backSvgs[svgIdx] ? (
-                            <img
-                              src={`data:image/svg+xml,${encodeURIComponent(backSvgs[svgIdx]!)}`}
-                              alt="Back"
-                              className="w-full h-full pointer-events-none"
-                              draggable={false}
-                            />
-                          ) : (
-                            <img
-                              src={entry.back}
-                              alt="Back"
-                              className="w-full h-full pointer-events-none"
-                              style={{ objectFit: (entry.backFit as any) || 'cover' }}
-                              draggable={false}
-                            />
-                          )}
+                          <img
+                            src={`data:image/svg+xml,${encodeURIComponent(backSvgs[svgIdx]!)}`}
+                            alt="Back"
+                            className="w-full h-full pointer-events-none"
+                            draggable={false}
+                          />
                         </div>
                       )}
-                      {showBack && !backSvgs[svgIdx] && !entry.back && config.printMode === 'back' && (
+                      {showBack && !backSvgs[svgIdx] && config.printMode === 'back' && (
                         <div className="w-full h-full bg-muted flex items-center justify-center text-xs text-muted-foreground">No back</div>
                       )}
                       {isFold && (

--- a/src/server.ts
+++ b/src/server.ts
@@ -592,7 +592,7 @@ app.post("/api/games/:gameId/collections/:collectionId/checkpoints", (req, res) 
   const createdAt = new Date().toISOString();
   const checkpoint = {
     id, name, createdAt,
-    collection: { name: col.name, layoutId: col.layoutId, backLayoutId: (col as any).backLayoutId, back: (col as any).back, backFit: (col as any).backFit },
+    collection: { name: col.name, layoutId: col.layoutId, backLayoutId: (col as any).backLayoutId },
     cards,
   };
   writeJson(checkpointPath(gameId, collectionId, id), checkpoint);
@@ -611,14 +611,12 @@ app.post("/api/games/:gameId/collections/:collectionId/checkpoints/:checkpointId
     const norm = normalizeCard(card);
     writeJson(collectionCardPath(gameId, collectionId, norm.id), norm);
   }
-  // Restore collection metadata (layout + back), keep id/name.
+  // Restore collection metadata (layout + back layout), keep id/name.
   const col = readJson<any>(collectionPath(gameId, collectionId), {});
   writeJson(collectionPath(gameId, collectionId), {
     ...col,
     layoutId: checkpoint.collection.layoutId,
     backLayoutId: checkpoint.collection.backLayoutId,
-    back: checkpoint.collection.back,
-    backFit: checkpoint.collection.backFit,
   });
   touchGame(gameId);
   res.status(204).end();

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -19,7 +19,7 @@ export type CheckpointMeta = { id: string; name: string; createdAt: string };
 
 /** A named, restorable snapshot of a collection's cards + metadata. */
 export type Checkpoint = CheckpointMeta & {
-  collection: { name: string; layoutId: string; backLayoutId?: string; back?: string; backFit?: "cover" | "contain" | "fill" };
+  collection: { name: string; layoutId: string; backLayoutId?: string };
   cards: CardData[];
 };
 

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -737,7 +737,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     const createdAt = now();
     const checkpoint = {
       id, name, createdAt,
-      collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit },
+      collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId },
       cards,
     };
     const folder = await checkpointsFolder(gameId, collectionId);
@@ -755,12 +755,10 @@ export const createGoogleDriveStorage = (options = {}) => {
     const current = await listCards(gameId, collectionId);
     for (const c of current) await deleteCard(gameId, collectionId, c.id);
     for (const card of checkpoint.cards ?? []) await saveCard(gameId, collectionId, card.id, card);
-    // Restore collection metadata (layout + back), keep id/name.
+    // Restore collection metadata (layout + back layout), keep id/name.
     await updateCollection(gameId, collectionId, {
       layoutId: checkpoint.collection.layoutId,
       backLayoutId: checkpoint.collection.backLayoutId,
-      back: checkpoint.collection.back,
-      backFit: checkpoint.collection.backFit,
     });
   };
 

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -552,7 +552,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
         const createdAt = now();
         const checkpoint = {
           id, name, createdAt,
-          collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit },
+          collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId },
           cards,
         };
         await idbPut(db, "checkpoints", [gameId, collectionId, id], checkpoint);
@@ -573,14 +573,12 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
           const normalized = normalizeCard(card);
           await idbPut(db, "cards", [gameId, collectionId, normalized.id], normalized);
         }
-        // Restore collection metadata (layout + back), keep id/name.
+        // Restore collection metadata (layout + back layout), keep id/name.
         const col = (await idbGet(db, "collections", [gameId, collectionId])) ?? { id: collectionId, name: collectionId };
         await idbPut(db, "collections", [gameId, collectionId], {
           ...col,
           layoutId: checkpoint.collection.layoutId,
           backLayoutId: checkpoint.collection.backLayoutId,
-          back: checkpoint.collection.back,
-          backFit: checkpoint.collection.backFit,
           updatedAt: now(),
         });
       } finally {

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -669,7 +669,7 @@ export const createS3Storage = (options = {}) => {
       const createdAt = now();
       const checkpoint = {
         id, name, createdAt,
-        collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit },
+        collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId },
         cards,
       };
       await putJson(checkpointKey(gameId, collectionId, id), checkpoint);
@@ -687,14 +687,12 @@ export const createS3Storage = (options = {}) => {
         const normalized = normalizeCard(card);
         await putJson(cardKey(gameId, collectionId, normalized.id), normalized);
       }
-      // Restore collection metadata (layout + back), keep id/name.
+      // Restore collection metadata (layout + back layout), keep id/name.
       const col = await getJson(collectionKey(gameId, collectionId));
       await putJson(collectionKey(gameId, collectionId), {
         ...col,
         layoutId: checkpoint.collection.layoutId,
         backLayoutId: checkpoint.collection.backLayoutId,
-        back: checkpoint.collection.back,
-        backFit: checkpoint.collection.backFit,
         updatedAt: now(),
       });
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,9 +133,6 @@ export type Collection = {
   id: string;
   name: string;
   layoutId: string;
-  // Card back: either a dedicated layout (rendered like the front) or a
-  // static image. backLayoutId takes precedence over back/backFit when set.
+  // Card back layout, rendered like the front. No back when unset.
   backLayoutId?: string;
-  back?: string;
-  backFit?: "cover" | "contain" | "fill";
 };

--- a/test/assetUsage.test.js
+++ b/test/assetUsage.test.js
@@ -25,7 +25,7 @@ const layoutWith = (overrides = {}) => ({
 test("image in layout item defaultValue is used", () => {
   const layout = layoutWith();
   layout.root.items.push({ id: "i1", type: "image", defaultValue: img("a.png") });
-  const used = collectUsedImageFiles([layout], [], []);
+  const used = collectUsedImageFiles([layout], []);
   assert.deepEqual([...used], ["a.png"]);
 });
 
@@ -39,13 +39,13 @@ test("image in nested section item is used", () => {
     }],
     items: [],
   });
-  const used = collectUsedImageFiles([layout], [], []);
+  const used = collectUsedImageFiles([layout], []);
   assert.ok(used.has("deep.png"));
 });
 
 test("image in card field value is used, including multiple URLs in one value", () => {
   const card = { id: "c1", name: "Card", fields: { art: img("b.png"), text: `see ${img("c.png")} and ${img("d.png")}` } };
-  const used = collectUsedImageFiles([], [], [card]);
+  const used = collectUsedImageFiles([], [card]);
   assert.deepEqual([...used].sort(), ["b.png", "c.png", "d.png"]);
 });
 
@@ -55,25 +55,20 @@ test("image in bindingMeta default and values is used", () => {
       "defaultValue:art": { default: img("def.png"), values: [img("v1.png"), img("v2.png")] },
     },
   });
-  const used = collectUsedImageFiles([layout], [], []);
+  const used = collectUsedImageFiles([layout], []);
   assert.deepEqual([...used].sort(), ["def.png", "v1.png", "v2.png"]);
-});
-
-test("image in collection back is used", () => {
-  const used = collectUsedImageFiles([], [{ id: "col1", back: img("back.png") }], []);
-  assert.ok(used.has("back.png"));
 });
 
 test("unreferenced images are not collected and URL matching is game-id-agnostic", () => {
   const card = { id: "c1", fields: { art: "/api/games/other-game/images/x.png" } };
-  const used = collectUsedImageFiles([], [], [card]);
+  const used = collectUsedImageFiles([], [card]);
   assert.ok(used.has("x.png"));
   assert.equal(used.size, 1);
 });
 
 test("image URL stops at quote/whitespace/markup delimiters", () => {
   const card = { id: "c1", fields: { t: `<img src="${img("q.png")}"> trailing` } };
-  const used = collectUsedImageFiles([], [], [card]);
+  const used = collectUsedImageFiles([], [card]);
   assert.deepEqual([...used], ["q.png"]);
 });
 

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -267,7 +267,7 @@ async function startServer() {
     const { name } = await c.req.json();
     const id = uid();
     const createdAt = new Date().toISOString();
-    const checkpoint = { id, name: name || "Checkpoint", createdAt, collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId, back: col.back, backFit: col.backFit }, cards: listCardsFor(gid, cid) };
+    const checkpoint = { id, name: name || "Checkpoint", createdAt, collection: { name: col.name, layoutId: col.layoutId, backLayoutId: col.backLayoutId }, cards: listCardsFor(gid, cid) };
     writeJson(chkPath(gid, cid, id), checkpoint);
     return c.json({ id, name: checkpoint.name, createdAt }, 201);
   });
@@ -280,7 +280,7 @@ async function startServer() {
     fs.mkdirSync(cdir, { recursive: true });
     for (const card of checkpoint.cards ?? []) writeJson(cardPath(gid, cid, card.id), card);
     const col = readJson(colPath(gid, cid), {});
-    writeJson(colPath(gid, cid), { ...col, layoutId: checkpoint.collection.layoutId, backLayoutId: checkpoint.collection.backLayoutId, back: checkpoint.collection.back, backFit: checkpoint.collection.backFit });
+    writeJson(colPath(gid, cid), { ...col, layoutId: checkpoint.collection.layoutId, backLayoutId: checkpoint.collection.backLayoutId });
     return c.body(null, 204);
   });
   app.delete("/api/games/:gid/collections/:cid/checkpoints/:chk", (c) => {
@@ -571,9 +571,9 @@ async function createFullTestGame(storage) {
   };
   await storage.saveLayout(gameId, tpl.id, tpl);
 
-  // Set back image on default collection
+  // Set a layout back on the default collection
   const cols = await storage.listCollections(gameId);
-  await storage.updateCollection(gameId, cols[0].id, { back: imageUrl, backFit: "contain" });
+  await storage.updateCollection(gameId, cols[0].id, { backLayoutId: tpl.id });
 
   // Cards
   await storage.saveCard(gameId, cols[0].id, "card-1", {
@@ -676,9 +676,7 @@ async function verifyFullTestGame(storage, gameId) {
 
   // Collection metadata
   const defCol = cols.find(c => c.name === "Default");
-  assert.ok(defCol.back, "Default collection should have a back image");
-  assert.ok(defCol.back.includes(`/api/games/${gameId}/images/`), "Back image URL should reference the game");
-  assert.equal(defCol.backFit, "contain");
+  assert.equal(defCol.backLayoutId, tpl.id, "backLayoutId must survive the round trip");
 
   // Cards
   const defCards = await storage.listCards(gameId, defCol.id);

--- a/test/dataPipeline.test.js
+++ b/test/dataPipeline.test.js
@@ -68,7 +68,7 @@ test("CSV round-trips commas, quotes and newlines", () => {
 
 // ── Zip export image collection ─────────────────────────────────────────────
 
-test("zip export collects all image refs: multi-image fields, bindingMeta, back", async () => {
+test("zip export collects all image refs: multi-image fields, bindingMeta", async () => {
   const gameId = "g1";
   const img = (f) => `/api/games/${gameId}/images/${f}`;
   const tpl = {
@@ -84,7 +84,7 @@ test("zip export collects all image refs: multi-image fields, bindingMeta, back"
     getGame: async () => ({ id: gameId, name: "G" }),
     listLayouts: async () => [tpl],
     listFonts: async () => ({}),
-    listCollections: async () => [{ id: "c1", name: "C", layoutId: "l1", back: img("back.png") }],
+    listCollections: async () => [{ id: "c1", name: "C", layoutId: "l1" }],
     listCards: async () => [{
       id: "k1", name: "K", fields: {
         rich: `<img src="${img("rich-1.png")}"> and <img src="${img("rich-2.png")}">`,
@@ -110,7 +110,7 @@ test("zip export collects all image refs: multi-image fields, bindingMeta, back"
     .map(u => u.split("/images/")[1])
     .sort();
   assert.deepEqual(requestedImages, [
-    "back.png", "item-default.png", "meta-default.png", "meta-value.png",
+    "item-default.png", "meta-default.png", "meta-value.png",
     "plain.png", "rich-1.png", "rich-2.png",
   ], "every referenced image (multi-match, bindingMeta default/values) must be exported with a clean filename");
 });


### PR DESCRIPTION
## Summary

Follow-up to #62. Card backs are now layout-only and are edited in place, exactly like fronts:

- The **Back tab** mirrors the front layout tab: a layout picker on top, with the full layout editor (node tree, properties, live preview) below it.
- The **Layout tab is renamed to Front** for coherence with the Back tab.
- Both pickers gain a **"+ New layout…"** entry that creates a layout (named after the collection) and assigns it to the collection's front or back immediately.
- The **static image back mode is removed** entirely — `Collection.back`/`backFit` are gone from the type, the Back tab, print/PDF preview and export, TTS export, zip export/import, checkpoints on all backends, and asset-usage scanning. A collection's back is a layout or nothing ("No back").
- The dead `back` prop on `LayoutEditorPanel`/`LayoutPreview` (a background-image pass-through that was no longer rendered) is removed.

## Testing

- Round-trip test now sets `backLayoutId` on both test collections and verifies it after every backend and cross-backend zip transfer; the checkpoint mini-server matches the real server's snapshot shape.
- Asset-usage and zip-export tests updated for the removed collection-back image reference.
- All 196 tests pass; `tsc` and the production Vite build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8)_