### PR TITLE
Compact unused-asset controls to fix mobile header overflow

### DIFF
--- a/src/components/FontManager.tsx
+++ b/src/components/FontManager.tsx
@@ -150,8 +150,8 @@ export default function FontManager({ gameId, fonts, onFontsChange, onStatus, sh
             <ConfirmButton
               variant="ghost"
               disabled={loading}
-              label={`${unusedCount} unused`}
-              title={`Delete ${unusedCount} unused font${unusedCount === 1 ? '' : 's'}`}
+              label={String(unusedCount)}
+              title={`Delete ${unusedCount} unused font${unusedCount === 1 ? '' : 's'} (not referenced by any layout, card or checkpoint)`}
               onConfirm={handleDeleteUnused}
             />
           )}

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Input } from '@/components/ui/input'
-import { ArrowLeft, Pencil, Copy, Plus, Check, Layers, Loader2 } from 'lucide-react'
+import { ArrowLeft, Pencil, Copy, Plus, Check, Layers, Loader2, ImageOff } from 'lucide-react'
 import ConfirmButton from '@/components/ConfirmButton'
 import ListItem from '@/components/ListItem'
 import { ValueItemEditor } from '@/components/layout/ControlPanel'
@@ -766,7 +766,10 @@ export default function CollectionsPage() {
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                   : <p className="text-sm text-muted-foreground">{showUnusedImagesOnly ? 'No unused images.' : 'No images yet.'}</p>}
                 subheader={showUnusedImagesOnly ? (
-                  <span className="text-xs text-muted-foreground">Not referenced by any layout, card, collection or checkpoint.</span>
+                  <span
+                    className="text-xs text-muted-foreground whitespace-nowrap"
+                    title="Not referenced by any layout, card, collection or checkpoint"
+                  >Unused only</span>
                 ) : undefined}
                 actions={selectedImage ? (<>
                   <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" title="Edit image"
@@ -793,13 +796,15 @@ export default function CollectionsPage() {
                     <Button
                       size="sm"
                       variant={showUnusedImagesOnly ? 'secondary' : 'ghost'}
+                      className="px-2 shrink-0"
                       onClick={() => setShowUnusedImagesOnly(v => !v)}
-                      title={showUnusedImagesOnly ? 'Show all images' : 'Show only unused images'}
+                      title={showUnusedImagesOnly ? 'Show all images' : `Show ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'} (not referenced by any layout, card, collection or checkpoint)`}
                     >
-                      {unusedImages.length} unused
+                      <ImageOff className="h-4 w-4" />
+                      <span className="ml-1 text-xs">{unusedImages.length}</span>
                     </Button>
                   )}
-                  {unusedImages.length > 0 && (
+                  {showUnusedImagesOnly && unusedImages.length > 0 && (
                     <ConfirmButton
                       variant="ghost"
                       title={`Delete ${unusedImages.length} unused image${unusedImages.length === 1 ? '' : 's'}`}


### PR DESCRIPTION
## Summary

Mobile layout fixes for the unused-asset UI from #64/#65:

- The `{n} unused` text button (plus the always-visible bulk-delete trash) made the Images header bar overflow on narrow screens.
- The subheader sentence "Not referenced by any layout, card, collection or checkpoint." wrapped to three lines, tripling the bar's height.

## Changes

- **Images toolbar**: the unused toggle is now a slim icon + count button (`ImageOff` + number). The bulk-delete trash only renders while the unused filter is active, so the default header carries one extra compact button instead of two wide ones.
- **Subheader**: shrinks to a non-wrapping "Unused only" label; the full explanation moved into the toggle's and label's tooltips.
- **Fonts toolbar**: the bulk-delete label shrinks from `{n} unused` to just the count, with the explanation in its tooltip.

## Testing

- `tsc`, `vite build`, and the full suite (197/197) pass. UI-only change, no behavior differences beyond the delete button's visibility being tied to the active filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9tHhGmWqQqk6DppXdY6VN

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9tHhGmWqQqk6DppXdY6VN)_