### PR TITLE
feat: version collections from the list page, add layout versions

### DIFF
--- a/src/components/CheckpointsDialog.tsx
+++ b/src/components/CheckpointsDialog.tsx
@@ -15,10 +15,10 @@ const defaultVersionName = () => {
 }
 
 /**
- * Collection versions: named, restorable snapshots of a collection
+ * Versions: named, restorable snapshots of a collection or a layout
  * (called "checkpoints" in the storage layer). Creating saves the current
- * cards + layout assignment; restoring replaces the current cards with the
- * snapshot (the editor auto-saves a "Before restore" version first).
+ * state; restoring replaces the current state with the snapshot (callers
+ * auto-save a "Before restore" version first).
  */
 export default function CheckpointsDialog({
   open,
@@ -29,6 +29,7 @@ export default function CheckpointsDialog({
   onCreate,
   onRestore,
   onDelete,
+  description = 'Save a version of this collection’s cards and layout, and restore it later.',
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -38,6 +39,7 @@ export default function CheckpointsDialog({
   onCreate: (name: string) => Promise<void> | void
   onRestore: (id: string) => Promise<void> | void
   onDelete: (id: string) => Promise<void> | void
+  description?: string
 }) {
   const [name, setName] = useState(defaultVersionName)
 
@@ -64,9 +66,7 @@ export default function CheckpointsDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2"><History className="h-4 w-4" /> Versions</DialogTitle>
-          <DialogDescription>
-            Save a version of this collection’s cards and layout, and restore it later.
-          </DialogDescription>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         <form className="flex gap-2 py-1" onSubmit={(e) => { e.preventDefault(); submit() }}>

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -22,6 +22,7 @@ export const queryKeys = {
   images: (gameId: string) => ['images', gameId] as const,
   checkpoints: (gameId: string, collectionId: string) => ['checkpoints', gameId, collectionId] as const,
   checkpoint: (gameId: string, collectionId: string, checkpointId: string) => ['checkpoint', gameId, collectionId, checkpointId] as const,
+  layoutCheckpoints: (gameId: string, layoutId: string) => ['layoutCheckpoints', gameId, layoutId] as const,
 }
 
 // ── Query hooks ─────────────────────────────────────────────────────
@@ -372,6 +373,52 @@ export function useDeleteCheckpoint(gameId: string | undefined, collectionId: st
   return useMutation<any, Error, string>({
     mutationFn: (checkpointId: string) => storage.deleteCheckpoint(gameId!, collectionId!, checkpointId),
     onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.checkpoints(gameId!, collectionId!) }) },
+  })
+}
+
+// ── Layout checkpoints ──────────────────────────────────────────────
+
+export function useLayoutCheckpoints(gameId: string | undefined, layoutId: string | undefined) {
+  const storage = useStorageInstance()!
+  return useQuery<{ id: string; name: string; createdAt: string }[]>({
+    queryKey: queryKeys.layoutCheckpoints(gameId!, layoutId!),
+    queryFn: () => storage.listLayoutCheckpoints(gameId!, layoutId!),
+    enabled: !!storage && !!gameId && !!layoutId,
+    staleTime: staleTime(),
+    gcTime: gcTime(),
+  })
+}
+
+export function useCreateLayoutCheckpoint(gameId: string | undefined, layoutId: string | undefined) {
+  const storage = useStorageInstance()!
+  const qc = useQueryClient()
+  return useMutation<any, Error, string>({
+    mutationFn: (name: string) => storage.createLayoutCheckpoint(gameId!, layoutId!, name),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.layoutCheckpoints(gameId!, layoutId!) }) },
+  })
+}
+
+export function useRestoreLayoutCheckpoint(gameId: string | undefined, layoutId: string | undefined) {
+  const storage = useStorageInstance()!
+  const qc = useQueryClient()
+  return useMutation<any, Error, string>({
+    mutationFn: (checkpointId: string) => storage.restoreLayoutCheckpoint(gameId!, layoutId!, checkpointId),
+    onSuccess: () => {
+      // The per-id layout query has staleTime: Infinity, so an explicit
+      // invalidation is the only way it ever refetches.
+      qc.invalidateQueries({ queryKey: queryKeys.layout(gameId!, layoutId!) })
+      qc.invalidateQueries({ queryKey: queryKeys.layouts(gameId!) })
+      qc.invalidateQueries({ queryKey: queryKeys.layoutCheckpoints(gameId!, layoutId!) })
+    },
+  })
+}
+
+export function useDeleteLayoutCheckpoint(gameId: string | undefined, layoutId: string | undefined) {
+  const storage = useStorageInstance()!
+  const qc = useQueryClient()
+  return useMutation<any, Error, string>({
+    mutationFn: (checkpointId: string) => storage.deleteLayoutCheckpoint(gameId!, layoutId!, checkpointId),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: queryKeys.layoutCheckpoints(gameId!, layoutId!) }) },
   })
 }
 

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -4,8 +4,9 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Input } from '@/components/ui/input'
-import { ArrowLeft, Pencil, Copy, Plus, Check, Layers, Loader2, ImageOff } from 'lucide-react'
+import { ArrowLeft, Pencil, Copy, Plus, Check, History, Layers, Loader2, ImageOff } from 'lucide-react'
 import ConfirmButton from '@/components/ConfirmButton'
+import CheckpointsDialog from '@/components/CheckpointsDialog'
 import ListItem from '@/components/ListItem'
 import { ValueItemEditor } from '@/components/layout/ControlPanel'
 import LayoutEditorPanel from '@/components/layout/LayoutEditorPanel'
@@ -23,6 +24,8 @@ import {
   useCreateLayout, useSaveLayout, useCopyLayout, useDeleteLayout,
   useSaveCard, useCopyCard, useDeleteCard,
   useUpdateGame, useUploadImage, useDeleteImage, useRenameImage,
+  useCheckpoints, useCreateCheckpoint, useRestoreCheckpoint, useDeleteCheckpoint,
+  useLayoutCheckpoints, useCreateLayoutCheckpoint, useRestoreLayoutCheckpoint, useDeleteLayoutCheckpoint,
   useInvalidateGame, queryKeys,
 } from '../hooks/useGameData'
 import FilesPanel from '@/components/FilesPanel'
@@ -159,6 +162,9 @@ export default function CollectionsPage() {
   const [newLayoutName, setNewLayoutName] = useState('')
   const [showCreateCollCard, setShowCreateCollCard] = useState(false)
   const [newCollCardName, setNewCollCardName] = useState('')
+  const [showCollectionVersions, setShowCollectionVersions] = useState(false)
+  const [showLayoutVersions, setShowLayoutVersions] = useState(false)
+  const [versionsBusy, setVersionsBusy] = useState(false)
 
   const [editingImage, setEditingImage] = useState(false)
 
@@ -178,6 +184,16 @@ export default function CollectionsPage() {
   const deleteImageMut = useDeleteImage(gameId)
   const renameImageMut = useRenameImage(gameId)
   const invalidateGame = useInvalidateGame(gameId)
+
+  // Versions (checkpoints) of the selected collection / layout
+  const { data: collectionCheckpoints = [], isLoading: collectionCheckpointsLoading } = useCheckpoints(gameId, expandedCollection ?? undefined)
+  const createCheckpointMut = useCreateCheckpoint(gameId, expandedCollection ?? undefined)
+  const restoreCheckpointMut = useRestoreCheckpoint(gameId, expandedCollection ?? undefined)
+  const deleteCheckpointMut = useDeleteCheckpoint(gameId, expandedCollection ?? undefined)
+  const { data: layoutCheckpoints = [], isLoading: layoutCheckpointsLoading } = useLayoutCheckpoints(gameId, selectedLayoutId ?? undefined)
+  const createLayoutCheckpointMut = useCreateLayoutCheckpoint(gameId, selectedLayoutId ?? undefined)
+  const restoreLayoutCheckpointMut = useRestoreLayoutCheckpoint(gameId, selectedLayoutId ?? undefined)
+  const deleteLayoutCheckpointMut = useDeleteLayoutCheckpoint(gameId, selectedLayoutId ?? undefined)
 
   const [layoutPreviewCards, setLayoutPreviewCards] = useState<any[]>([])
 
@@ -337,6 +353,64 @@ export default function CollectionsPage() {
     }
   }
 
+  // --- Version (checkpoint) handlers ---
+
+  const handleCreateCollectionVersion = async (name: string) => {
+    setVersionsBusy(true)
+    try {
+      await createCheckpointMut.mutateAsync(name)
+      setStatus('Version saved.')
+    } catch { setStatus('Error saving version.') }
+    finally { setVersionsBusy(false) }
+  }
+
+  const handleRestoreCollectionVersion = async (checkpointId: string) => {
+    setVersionsBusy(true)
+    try {
+      // Safety net: snapshot the current state before overwriting it.
+      try { await createCheckpointMut.mutateAsync(`Before restore — ${new Date().toLocaleString()}`) } catch { /* non-fatal */ }
+      await restoreCheckpointMut.mutateAsync(checkpointId)
+      setShowCollectionVersions(false)
+      setStatus('Version restored.')
+    } catch { setStatus('Error restoring version.') }
+    finally { setVersionsBusy(false) }
+  }
+
+  const handleDeleteCollectionVersion = async (checkpointId: string) => {
+    setVersionsBusy(true)
+    try { await deleteCheckpointMut.mutateAsync(checkpointId) }
+    catch { setStatus('Error deleting version.') }
+    finally { setVersionsBusy(false) }
+  }
+
+  const handleCreateLayoutVersion = async (name: string) => {
+    setVersionsBusy(true)
+    try {
+      await createLayoutCheckpointMut.mutateAsync(name)
+      setStatus('Layout version saved.')
+    } catch { setStatus('Error saving layout version.') }
+    finally { setVersionsBusy(false) }
+  }
+
+  const handleRestoreLayoutVersion = async (checkpointId: string) => {
+    setVersionsBusy(true)
+    try {
+      // Safety net: snapshot the current state before overwriting it.
+      try { await createLayoutCheckpointMut.mutateAsync(`Before restore — ${new Date().toLocaleString()}`) } catch { /* non-fatal */ }
+      await restoreLayoutCheckpointMut.mutateAsync(checkpointId)
+      setShowLayoutVersions(false)
+      setStatus('Layout version restored.')
+    } catch { setStatus('Error restoring layout version.') }
+    finally { setVersionsBusy(false) }
+  }
+
+  const handleDeleteLayoutVersion = async (checkpointId: string) => {
+    setVersionsBusy(true)
+    try { await deleteLayoutCheckpointMut.mutateAsync(checkpointId) }
+    catch { setStatus('Error deleting layout version.') }
+    finally { setVersionsBusy(false) }
+  }
+
 
   if (!game) {
     return (
@@ -447,6 +521,9 @@ export default function CollectionsPage() {
                     setSearchParams({ tab: 'layouts' }, { replace: true })
                   }} title="Edit layout">
                     <Layers className="h-4 w-4" />
+                  </button>
+                  <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" onClick={() => setShowCollectionVersions(true)} title="Versions">
+                    <History className="h-4 w-4" />
                   </button>
                   <ConfirmButton iconOnly onConfirm={async () => {
                     try {
@@ -638,6 +715,9 @@ export default function CollectionsPage() {
                       } catch { setStatus('Error copying layout.') }
                     }}>
                       <Copy className="h-4 w-4" />
+                    </button>
+                    <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors" onClick={() => setShowLayoutVersions(true)} title="Versions">
+                      <History className="h-4 w-4" />
                     </button>
                     <ConfirmButton iconOnly onConfirm={async () => {
                       try {
@@ -877,6 +957,27 @@ export default function CollectionsPage() {
             <GameFilesPanel gameId={gameId!} game={game} layouts={layouts} collections={collections} gameFonts={gameFonts} onStatusChange={setStatus} />
           </TabsContent>
         </Tabs>
+        <CheckpointsDialog
+          open={showCollectionVersions && !!expandedCollection}
+          onOpenChange={setShowCollectionVersions}
+          checkpoints={collectionCheckpoints}
+          loading={collectionCheckpointsLoading}
+          busy={versionsBusy}
+          onCreate={handleCreateCollectionVersion}
+          onRestore={handleRestoreCollectionVersion}
+          onDelete={handleDeleteCollectionVersion}
+        />
+        <CheckpointsDialog
+          open={showLayoutVersions && !!selectedLayoutId}
+          onOpenChange={setShowLayoutVersions}
+          checkpoints={layoutCheckpoints}
+          loading={layoutCheckpointsLoading}
+          busy={versionsBusy}
+          onCreate={handleCreateLayoutVersion}
+          onRestore={handleRestoreLayoutVersion}
+          onDelete={handleDeleteLayoutVersion}
+          description="Save a version of this layout, and restore it later."
+        />
     </PageLayout>
   )
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -431,6 +431,7 @@ app.delete("/api/games/:gameId/layouts/:layoutId", (req, res) => {
   const collections = listCollections(gameId);
   if (collections.some((col) => col.layoutId === layoutId)) return res.status(400).json({ error: "Layout is in use by a collection" });
   fs.rmSync(layoutFilePath(gameId, layoutId), { force: true });
+  fs.rmSync(layoutCheckpointsDir(gameId, layoutId), { recursive: true, force: true });
   touchGame(gameId);
   res.status(204).end();
 });
@@ -625,6 +626,53 @@ app.post("/api/games/:gameId/collections/:collectionId/checkpoints/:checkpointId
 app.delete("/api/games/:gameId/collections/:collectionId/checkpoints/:checkpointId", (req, res) => {
   const { gameId, collectionId, checkpointId } = req.params;
   fs.rmSync(checkpointPath(gameId, collectionId, checkpointId), { force: true });
+  res.status(204).end();
+});
+
+// Layout checkpoints (named, restorable snapshots of a layout).
+// Stored outside layoutsDir so listLayouts never picks them up.
+const layoutCheckpointsDir = (gameId: string, layoutId: string) => path.join(dataRoot, gameId, "layout-checkpoints", layoutId);
+const layoutCheckpointPath = (gameId: string, layoutId: string, id: string) => path.join(layoutCheckpointsDir(gameId, layoutId), `${id}.json`);
+
+app.get("/api/games/:gameId/layouts/:layoutId/checkpoints", (req, res) => {
+  const { gameId, layoutId } = req.params;
+  const dir = layoutCheckpointsDir(gameId, layoutId);
+  if (!fs.existsSync(dir)) return res.json([]);
+  const metas = fs.readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => readJson<any>(path.join(dir, f), null))
+    .filter(Boolean)
+    .map((cp: any) => ({ id: cp.id, name: cp.name, createdAt: cp.createdAt }))
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  res.json(metas);
+});
+
+app.post("/api/games/:gameId/layouts/:layoutId/checkpoints", (req, res) => {
+  const { gameId, layoutId } = req.params;
+  const name = req.body?.name?.trim() || "Version";
+  const layout = loadLayout(gameId, layoutId);
+  if (!layout) return res.status(404).json({ error: "Layout not found" });
+  const id = crypto.randomUUID().slice(0, 8);
+  const createdAt = new Date().toISOString();
+  writeJson(layoutCheckpointPath(gameId, layoutId, id), { id, name, createdAt, layout });
+  res.status(201).json({ id, name, createdAt });
+});
+
+app.post("/api/games/:gameId/layouts/:layoutId/checkpoints/:checkpointId/restore", (req, res) => {
+  const { gameId, layoutId, checkpointId } = req.params;
+  const checkpoint = readJson<any>(layoutCheckpointPath(gameId, layoutId, checkpointId), null);
+  if (!checkpoint?.layout) return res.status(404).json({ error: "Checkpoint not found" });
+  // Restore the layout's content but keep the current id and name.
+  const current = loadLayout(gameId, layoutId);
+  const restored = normalizeLayout({ ...checkpoint.layout, id: layoutId, name: current?.name ?? checkpoint.layout.name });
+  writeJson(layoutFilePath(gameId, layoutId), restored);
+  touchGame(gameId);
+  res.status(204).end();
+});
+
+app.delete("/api/games/:gameId/layouts/:layoutId/checkpoints/:checkpointId", (req, res) => {
+  const { gameId, layoutId, checkpointId } = req.params;
+  fs.rmSync(layoutCheckpointPath(gameId, layoutId, checkpointId), { force: true });
   res.status(204).end();
 });
 

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -23,6 +23,11 @@ export type Checkpoint = CheckpointMeta & {
   cards: CardData[];
 };
 
+/** A named, restorable snapshot of a layout. */
+export type LayoutCheckpoint = CheckpointMeta & {
+  layout: CardLayout;
+};
+
 /**
  * The contract every storage backend (localFile, indexedDB, s3, googleDrive)
  * implements. The implementations are plain JS — this interface is what the
@@ -92,4 +97,12 @@ export interface StorageBackend {
   createCheckpoint(gameId: string, collectionId: string, name: string): Promise<CheckpointMeta>;
   restoreCheckpoint(gameId: string, collectionId: string, checkpointId: string): Promise<void>;
   deleteCheckpoint(gameId: string, collectionId: string, checkpointId: string): Promise<void>;
+
+  // Named, restorable snapshots of a layout. Restore replaces the layout's
+  // content with the snapshot but keeps the current id and name (mirroring
+  // how collection restore keeps the collection's id/name).
+  listLayoutCheckpoints(gameId: string, layoutId: string): Promise<CheckpointMeta[]>;
+  createLayoutCheckpoint(gameId: string, layoutId: string, name: string): Promise<CheckpointMeta>;
+  restoreLayoutCheckpoint(gameId: string, layoutId: string, checkpointId: string): Promise<void>;
+  deleteLayoutCheckpoint(gameId: string, layoutId: string, checkpointId: string): Promise<void>;
 }

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -405,6 +405,15 @@ export const createGoogleDriveStorage = (options = {}) => {
     const fid = fileIds.get(key) ?? await findFile(`${layoutId}.json`, await layoutsFolder(gameId));
     if (fid) await rmFile(fid);
     fileIds.delete(key);
+    // Drop the layout's checkpoints folder along with it.
+    const chkParent = folderIds.get(`tplchk:${gameId}`)
+      ?? (await foldersIn(await gameFolder(gameId))).find((f) => f.name === "layout-checkpoints")?.id;
+    if (chkParent) {
+      const chkFolder = folderIds.get(`tplchk:${gameId}:${layoutId}`)
+        ?? (await foldersIn(chkParent)).find((f) => f.name === layoutId)?.id;
+      if (chkFolder) await rmFile(chkFolder);
+    }
+    folderIds.delete(`tplchk:${gameId}:${layoutId}`);
   };
 
   const copyLayout = async (gameId, layoutId) => {
@@ -769,6 +778,58 @@ export const createGoogleDriveStorage = (options = {}) => {
     fileIds.delete(key);
   };
 
+  // --- Layout checkpoints ---
+
+  const layoutCheckpointsFolder = async (gameId, layoutId) => {
+    const parent = await ensureFolder(await gameFolder(gameId), "layout-checkpoints", `tplchk:${gameId}`);
+    return ensureFolder(parent, layoutId, `tplchk:${gameId}:${layoutId}`);
+  };
+
+  const listLayoutCheckpoints = async (gameId, layoutId) => {
+    const folder = await layoutCheckpointsFolder(gameId, layoutId);
+    const files = await filesInFolder(folder);
+    const metas = [];
+    for (const f of files) {
+      if (!f.name.endsWith(".json")) continue;
+      const cp = await readFile(f.id);
+      if (cp?.id) {
+        metas.push({ id: cp.id, name: cp.name, createdAt: cp.createdAt });
+        fileIds.set(`tplchkfile:${gameId}:${layoutId}:${cp.id}`, f.id);
+      }
+    }
+    metas.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+    return metas;
+  };
+
+  const createLayoutCheckpoint = async (gameId, layoutId, name) => {
+    const layout = await getLayout(gameId, layoutId);
+    const id = uid();
+    const createdAt = now();
+    const checkpoint = { id, name, createdAt, layout };
+    const folder = await layoutCheckpointsFolder(gameId, layoutId);
+    const fid = await mkFile(`${id}.json`, checkpoint, folder, { type: "layout-checkpoint", gameId, layoutId });
+    fileIds.set(`tplchkfile:${gameId}:${layoutId}:${id}`, fid);
+    return { id, name, createdAt };
+  };
+
+  const restoreLayoutCheckpoint = async (gameId, layoutId, checkpointId) => {
+    const key = `tplchkfile:${gameId}:${layoutId}:${checkpointId}`;
+    const fid = fileIds.get(key) ?? await findFile(`${checkpointId}.json`, await layoutCheckpointsFolder(gameId, layoutId));
+    if (!fid) throw new Error("Checkpoint not found.");
+    const checkpoint = await readFile(fid);
+    // Restore the layout's content but keep the current id and name.
+    const current = await getLayout(gameId, layoutId);
+    const restored = normalizeLayout({ ...checkpoint.layout, id: layoutId, name: current?.name ?? checkpoint.layout.name });
+    await saveLayout(gameId, layoutId, restored);
+  };
+
+  const deleteLayoutCheckpoint = async (gameId, layoutId, checkpointId) => {
+    const key = `tplchkfile:${gameId}:${layoutId}:${checkpointId}`;
+    const fid = fileIds.get(key) ?? await findFile(`${checkpointId}.json`, await layoutCheckpointsFolder(gameId, layoutId));
+    if (fid) await rmFile(fid);
+    fileIds.delete(key);
+  };
+
   return {
     init, signIn, signOut, tryRestoreSession, isAuthorized,
     listGames, getGame, createGame, updateGame, deleteGame,
@@ -778,6 +839,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     listFonts, addGoogleFont, uploadFont, deleteFont, renameFont,
     uploadImage, listImages, deleteImage, renameImage,
     listCheckpoints, getCheckpoint, createCheckpoint, restoreCheckpoint, deleteCheckpoint,
+    listLayoutCheckpoints, createLayoutCheckpoint, restoreLayoutCheckpoint, deleteLayoutCheckpoint,
     clearCache,
   };
 };

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -26,7 +26,7 @@ const hashArrayBuffer = async (buf) => {
 // ── Database ───────────────────────────────────────────────────────────────
 
 const DB_NAME = "boardgame-assets";
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 
 function openDB() {
   return new Promise((resolve, reject) => {
@@ -53,6 +53,9 @@ function openDB() {
       }
       if (!db.objectStoreNames.contains("checkpoints")) {
         db.createObjectStore("checkpoints");
+      }
+      if (!db.objectStoreNames.contains("layoutCheckpoints")) {
+        db.createObjectStore("layoutCheckpoints");
       }
 
       // Migrate v2 "templates" → "layouts" and rename templateId in collections
@@ -300,10 +303,12 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
         await idbDelete(db, "games", gameId);
         await idbDelete(db, "games", fontsKey(gameId));
 
-        // Delete all layouts, collections, cards for this game
+        // Delete all layouts, collections, cards and checkpoints for this game
         await idbDeleteByPrefix(db, "layouts", [gameId]);
         await idbDeleteByPrefix(db, "collections", [gameId]);
         await idbDeleteByPrefix(db, "cards", [gameId]);
+        await idbDeleteByPrefix(db, "checkpoints", [gameId]);
+        await idbDeleteByPrefix(db, "layoutCheckpoints", [gameId]);
 
         // Delete all assets for this game
         const prefix = `/api/games/${gameId}/`;
@@ -390,6 +395,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
           throw new Error("Cannot delete layout that is in use by a collection");
         }
         await idbDelete(db, "layouts", [gameId, layoutId]);
+        await idbDeleteByPrefix(db, "layoutCheckpoints", [gameId, layoutId]);
       } finally {
         db.close();
       }
@@ -590,6 +596,58 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
       const db = await openDB();
       try {
         await idbDelete(db, "checkpoints", [gameId, collectionId, checkpointId]);
+      } finally {
+        db.close();
+      }
+    },
+
+    // ── Layout checkpoints ───────────────────────────────────────────────────
+
+    async listLayoutCheckpoints(gameId, layoutId) {
+      const db = await openDB();
+      try {
+        const entries = await idbGetAllByPrefix(db, "layoutCheckpoints", [gameId, layoutId]);
+        return entries
+          .map((e) => ({ id: e.value.id, name: e.value.name, createdAt: e.value.createdAt }))
+          .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+      } finally {
+        db.close();
+      }
+    },
+
+    async createLayoutCheckpoint(gameId, layoutId, name) {
+      const db = await openDB();
+      try {
+        const layout = await idbGet(db, "layouts", [gameId, layoutId]);
+        if (!layout) throw new Error(`Layout not found: ${layoutId}`);
+        const id = uid();
+        const createdAt = now();
+        const checkpoint = { id, name, createdAt, layout: normalizeLayout(layout) };
+        await idbPut(db, "layoutCheckpoints", [gameId, layoutId, id], checkpoint);
+        return { id, name, createdAt };
+      } finally {
+        db.close();
+      }
+    },
+
+    async restoreLayoutCheckpoint(gameId, layoutId, checkpointId) {
+      const db = await openDB();
+      try {
+        const checkpoint = await idbGet(db, "layoutCheckpoints", [gameId, layoutId, checkpointId]);
+        if (!checkpoint) throw new Error(`Checkpoint not found: ${checkpointId}`);
+        // Restore the layout's content but keep the current id and name.
+        const current = await idbGet(db, "layouts", [gameId, layoutId]);
+        const restored = normalizeLayout({ ...checkpoint.layout, id: layoutId, name: current?.name ?? checkpoint.layout.name });
+        await idbPut(db, "layouts", [gameId, layoutId], restored);
+      } finally {
+        db.close();
+      }
+    },
+
+    async deleteLayoutCheckpoint(gameId, layoutId, checkpointId) {
+      const db = await openDB();
+      try {
+        await idbDelete(db, "layoutCheckpoints", [gameId, layoutId, checkpointId]);
       } finally {
         db.close();
       }

--- a/src/storage/localFile.js
+++ b/src/storage/localFile.js
@@ -302,6 +302,33 @@ export const createLocalFileStorage = ({ defaultLayout }) => {
     async deleteCheckpoint(gameId, collectionId, checkpointId) {
       const response = await fetch(`${apiBase}/games/${gameId}/collections/${collectionId}/checkpoints/${checkpointId}`, { method: "DELETE" });
       if (!response.ok) throw new Error("Failed to delete checkpoint");
+    },
+
+    // Layout checkpoints
+    async listLayoutCheckpoints(gameId, layoutId) {
+      const response = await fetch(`${apiBase}/games/${gameId}/layouts/${layoutId}/checkpoints`);
+      if (!response.ok) throw new Error("Failed to list layout checkpoints");
+      return await response.json();
+    },
+
+    async createLayoutCheckpoint(gameId, layoutId, name) {
+      const response = await fetch(`${apiBase}/games/${gameId}/layouts/${layoutId}/checkpoints`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!response.ok) throw new Error("Failed to create layout checkpoint");
+      return await response.json();
+    },
+
+    async restoreLayoutCheckpoint(gameId, layoutId, checkpointId) {
+      const response = await fetch(`${apiBase}/games/${gameId}/layouts/${layoutId}/checkpoints/${checkpointId}/restore`, { method: "POST" });
+      if (!response.ok) throw new Error("Failed to restore layout checkpoint");
+    },
+
+    async deleteLayoutCheckpoint(gameId, layoutId, checkpointId) {
+      const response = await fetch(`${apiBase}/games/${gameId}/layouts/${layoutId}/checkpoints/${checkpointId}`, { method: "DELETE" });
+      if (!response.ok) throw new Error("Failed to delete layout checkpoint");
     }
   };
 };

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -201,6 +201,11 @@ export const createS3Storage = (options = {}) => {
     `${prefix}/${gameId}/collections/${collectionId}/checkpoints/${checkpointId}.json`;
   const checkpointsPrefix = (gameId, collectionId) =>
     `${prefix}/${gameId}/collections/${collectionId}/checkpoints/`;
+  // Outside layouts/ so listLayouts (which sweeps that prefix) never sees them.
+  const layoutCheckpointKey = (gameId, layoutId, checkpointId) =>
+    `${prefix}/${gameId}/layout-checkpoints/${layoutId}/${checkpointId}.json`;
+  const layoutCheckpointsPrefix = (gameId, layoutId) =>
+    `${prefix}/${gameId}/layout-checkpoints/${layoutId}/`;
   const fontsManifestKey = (gameId) =>
     `${prefix}/${gameId}/fonts/fonts.json`;
 
@@ -356,6 +361,7 @@ export const createS3Storage = (options = {}) => {
         throw new Error("Layout is in use by a collection");
       }
       await deleteObject(layoutKey(gameId, layoutId));
+      await deleteAllWithPrefix(layoutCheckpointsPrefix(gameId, layoutId));
     },
 
     // ── Collections ────────────────────────────────────────────────────────
@@ -699,6 +705,44 @@ export const createS3Storage = (options = {}) => {
 
     async deleteCheckpoint(gameId, collectionId, checkpointId) {
       await deleteObject(checkpointKey(gameId, collectionId, checkpointId));
+    },
+
+    // ── Layout checkpoints ───────────────────────────────────────────────────
+
+    async listLayoutCheckpoints(gameId, layoutId) {
+      const keys = await listKeys(layoutCheckpointsPrefix(gameId, layoutId));
+      const metas = [];
+      for (const key of keys) {
+        if (!key.endsWith(".json")) continue;
+        try {
+          const cp = await getJson(key);
+          metas.push({ id: cp.id, name: cp.name, createdAt: cp.createdAt });
+        } catch { /* skip corrupt */ }
+      }
+      metas.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)); // newest first
+      return metas;
+    },
+
+    async createLayoutCheckpoint(gameId, layoutId, name) {
+      const layout = await getJson(layoutKey(gameId, layoutId));
+      const id = uid();
+      const createdAt = now();
+      const checkpoint = { id, name, createdAt, layout: normalizeLayout({ ...layout, id: layoutId }) };
+      await putJson(layoutCheckpointKey(gameId, layoutId, id), checkpoint);
+      return { id, name, createdAt };
+    },
+
+    async restoreLayoutCheckpoint(gameId, layoutId, checkpointId) {
+      const checkpoint = await getJson(layoutCheckpointKey(gameId, layoutId, checkpointId));
+      // Restore the layout's content but keep the current id and name.
+      let currentName;
+      try { currentName = (await getJson(layoutKey(gameId, layoutId)))?.name; } catch { /* layout missing */ }
+      const restored = normalizeLayout({ ...checkpoint.layout, id: layoutId, name: currentName ?? checkpoint.layout.name });
+      await putJson(layoutKey(gameId, layoutId), restored);
+    },
+
+    async deleteLayoutCheckpoint(gameId, layoutId, checkpointId) {
+      await deleteObject(layoutCheckpointKey(gameId, layoutId, checkpointId));
     },
   };
 };

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -176,7 +176,9 @@ async function startServer() {
     return c.json(body);
   });
   app.delete("/api/games/:gid/layouts/:tid", (c) => {
-    fs.rmSync(tplPath(c.req.param("gid"), c.req.param("tid")), { force: true }); return c.json({});
+    fs.rmSync(tplPath(c.req.param("gid"), c.req.param("tid")), { force: true });
+    fs.rmSync(path.join(dataRoot, c.req.param("gid"), "layout-checkpoints", c.req.param("tid")), { recursive: true, force: true });
+    return c.json({});
   });
   app.post("/api/games/:gid/layouts/:tid/copy", (c) => {
     const orig = readJson(tplPath(c.req.param("gid"), c.req.param("tid")), null);
@@ -285,6 +287,40 @@ async function startServer() {
   });
   app.delete("/api/games/:gid/collections/:cid/checkpoints/:chk", (c) => {
     fs.rmSync(chkPath(c.req.param("gid"), c.req.param("cid"), c.req.param("chk")), { force: true });
+    return c.body(null, 204);
+  });
+
+  // Layout checkpoints
+  const tplChkDir = (gid, tid) => path.join(dataRoot, gid, "layout-checkpoints", tid);
+  const tplChkPath = (gid, tid, id) => path.join(tplChkDir(gid, tid), `${id}.json`);
+  app.get("/api/games/:gid/layouts/:tid/checkpoints", (c) => {
+    const dir = tplChkDir(c.req.param("gid"), c.req.param("tid"));
+    if (!fs.existsSync(dir)) return c.json([]);
+    return c.json(fs.readdirSync(dir).filter(f => f.endsWith(".json"))
+      .map(f => readJson(path.join(dir, f), null)).filter(Boolean)
+      .map(cp => ({ id: cp.id, name: cp.name, createdAt: cp.createdAt }))
+      .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1)));
+  });
+  app.post("/api/games/:gid/layouts/:tid/checkpoints", async (c) => {
+    const gid = c.req.param("gid"), tid = c.req.param("tid");
+    const layout = readJson(tplPath(gid, tid), null);
+    if (!layout) return c.json({ error: "Layout not found" }, 404);
+    const { name } = await c.req.json();
+    const id = uid();
+    const createdAt = new Date().toISOString();
+    writeJson(tplChkPath(gid, tid, id), { id, name: name || "Version", createdAt, layout });
+    return c.json({ id, name: name || "Version", createdAt }, 201);
+  });
+  app.post("/api/games/:gid/layouts/:tid/checkpoints/:chk/restore", (c) => {
+    const gid = c.req.param("gid"), tid = c.req.param("tid");
+    const checkpoint = readJson(tplChkPath(gid, tid, c.req.param("chk")), null);
+    if (!checkpoint?.layout) return c.json({ error: "Checkpoint not found" }, 404);
+    const current = readJson(tplPath(gid, tid), null);
+    writeJson(tplPath(gid, tid), { ...checkpoint.layout, id: tid, name: current?.name ?? checkpoint.layout.name });
+    return c.body(null, 204);
+  });
+  app.delete("/api/games/:gid/layouts/:tid/checkpoints/:chk", (c) => {
+    fs.rmSync(tplChkPath(c.req.param("gid"), c.req.param("tid"), c.req.param("chk")), { force: true });
     return c.body(null, 204);
   });
 
@@ -962,4 +998,50 @@ describe("collection checkpoints", () => {
   checkpointSuite("localFile", async () => createLocalFileStorage({ defaultLayout }));
   checkpointSuite("indexedDB", async () => createIndexedDBStorage({ defaultLayout }));
   checkpointSuite("s3", async () => createTestS3());
+});
+
+// ── Layout checkpoints (named, restorable snapshots of a layout) ───────────
+
+function layoutCheckpointSuite(name, makeStorage) {
+  it(`${name}: layout checkpoint captures the layout, restore keeps current id/name`, async () => {
+    const s = await makeStorage();
+    const game = await s.createGame("Layout Checkpoint Test");
+    const tpl = (await s.listLayouts(game.id))[0];
+
+    // Give the layout a recognizable state and snapshot it.
+    await s.saveLayout(game.id, tpl.id, { ...tpl, width: 63, height: 88 });
+    const cp = await s.createLayoutCheckpoint(game.id, tpl.id, "v1");
+    assert.ok(cp.id, "checkpoint has an id");
+    assert.equal(cp.name, "v1");
+    assert.ok(cp.createdAt, "checkpoint has createdAt");
+
+    const list = await s.listLayoutCheckpoints(game.id, tpl.id);
+    assert.equal(list.length, 1, "one layout checkpoint listed");
+    assert.equal(list[0].name, "v1");
+
+    // Mutate after the checkpoint: resize and rename.
+    await s.saveLayout(game.id, tpl.id, { ...tpl, width: 100, height: 150, name: "Renamed" });
+
+    await s.restoreLayoutCheckpoint(game.id, tpl.id, cp.id);
+    const restored = await s.getLayout(game.id, tpl.id);
+    assert.equal(restored.width, 63, "width reverted to snapshot");
+    assert.equal(restored.height, 88, "height reverted to snapshot");
+    assert.equal(restored.id, tpl.id, "id unchanged by restore");
+    assert.equal(restored.name, "Renamed", "current name kept on restore");
+
+    await s.deleteLayoutCheckpoint(game.id, tpl.id, cp.id);
+    assert.equal((await s.listLayoutCheckpoints(game.id, tpl.id)).length, 0, "layout checkpoint deleted");
+
+    // Deleting a layout removes its checkpoints too.
+    const tpl2 = await s.createLayout(game.id, "Disposable");
+    await s.createLayoutCheckpoint(game.id, tpl2.id, "orphan?");
+    await s.deleteLayout(game.id, tpl2.id);
+    assert.equal((await s.listLayoutCheckpoints(game.id, tpl2.id)).length, 0, "checkpoints removed with layout");
+  });
+}
+
+describe("layout checkpoints", () => {
+  layoutCheckpointSuite("localFile", async () => createLocalFileStorage({ defaultLayout }));
+  layoutCheckpointSuite("indexedDB", async () => createIndexedDBStorage({ defaultLayout }));
+  layoutCheckpointSuite("s3", async () => createTestS3());
 });

--- a/test/storageCaching.test.js
+++ b/test/storageCaching.test.js
@@ -460,6 +460,36 @@ test("googleDrive: checkpoint captures cards + layout and restore reverts change
   assert.equal((await storage.listCheckpoints(game.id, "default")).length, 0);
 });
 
+test("googleDrive: layout checkpoint captures the layout and restore keeps current id/name", async () => {
+  createDriveMock();
+  const storage = await makeStorage();
+  const game = await storage.createGame("Layout Checkpoint Game");
+  const tpl = (await storage.listLayouts(game.id))[0];
+
+  await storage.saveLayout(game.id, tpl.id, { ...tpl, width: 63, height: 88 });
+  const cp = await storage.createLayoutCheckpoint(game.id, tpl.id, "v1");
+  assert.ok(cp.id && cp.name === "v1" && cp.createdAt);
+  assert.equal((await storage.listLayoutCheckpoints(game.id, tpl.id)).length, 1);
+
+  await storage.saveLayout(game.id, tpl.id, { ...tpl, width: 100, height: 150, name: "Renamed" });
+
+  await storage.restoreLayoutCheckpoint(game.id, tpl.id, cp.id);
+  const restored = await storage.getLayout(game.id, tpl.id);
+  assert.equal(restored.width, 63, "width reverted to snapshot");
+  assert.equal(restored.height, 88, "height reverted to snapshot");
+  assert.equal(restored.id, tpl.id, "id unchanged by restore");
+  assert.equal(restored.name, "Renamed", "current name kept on restore");
+
+  await storage.deleteLayoutCheckpoint(game.id, tpl.id, cp.id);
+  assert.equal((await storage.listLayoutCheckpoints(game.id, tpl.id)).length, 0);
+
+  // Deleting a layout removes its checkpoints too.
+  const tpl2 = await storage.createLayout(game.id, "Disposable");
+  await storage.createLayoutCheckpoint(game.id, tpl2.id, "orphan?");
+  await storage.deleteLayout(game.id, tpl2.id);
+  assert.equal((await storage.listLayoutCheckpoints(game.id, tpl2.id)).length, 0, "checkpoints removed with layout");
+});
+
 // ── clearCache exists on every backend ─────────────────────────────────────
 
 test("all backends expose clearCache for reload-from-storage", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #61, addressing two gaps: there was no way to open the Versions dialog from the collection list (it was only reachable inside the card editor), and layouts couldn't be versioned at all.

### Versions from the collection list

The Collections tab now shows a history button on the selected collection's action row, opening the same Versions dialog the card editor uses (date-defaulted name, restore, delete). Restoring auto-saves a "Before restore" safety snapshot first, matching the editor's behavior.

### Layout versions

- The Layouts tab gets the same history button for the selected layout.
- The storage contract gains `listLayoutCheckpoints` / `createLayoutCheckpoint` / `restoreLayoutCheckpoint` / `deleteLayoutCheckpoint`, implemented in all four backends:
  - **localFile + server**: stored under `games/<id>/layout-checkpoints/<layoutId>/`, outside `layouts/` so `listLayouts` never picks snapshots up.
  - **indexedDB**: DB schema v5 with a new `layoutCheckpoints` store; `deleteGame` now also clears both checkpoint stores (pre-existing gap).
  - **S3**: keys under a dedicated `layout-checkpoints/` prefix (the `layouts/` prefix is swept recursively by `listLayouts`).
  - **Google Drive**: a `layout-checkpoints/<layoutId>` folder under the game folder.
- Restore replaces the layout's content but keeps its current id and name, mirroring how collection restore keeps the collection's id/name.
- Deleting a layout deletes its checkpoints in every backend.

## Testing

- New `layoutCheckpointSuite` in `test/backendCompat.test.js` (localFile, indexedDB, S3) and a Google Drive test in `test/storageCaching.test.js`: snapshot → mutate → restore semantics, id/name preservation, and checkpoint cleanup on layout deletion.
- `npx tsc --noEmit` clean; full suite 201/201 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5BKJUrUWjS2zj1DfwMTY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5BKJUrUWjS2zj1DfwMTY1)_