### PR TITLE
Fix ignored offsets on clone items and rename copy → clone

### DIFF
--- a/src/components/layout/ControlPanel.tsx
+++ b/src/components/layout/ControlPanel.tsx
@@ -119,7 +119,7 @@ const getFieldMeta = (property: string, layout: CardLayout, selectedNodeId?: str
     case 'anchor':
     case 'attachAnchor': return { type: 'anchor' }
     case 'visible': return { type: 'boolean' }
-    case 'copyTargetId': {
+    case 'cloneTargetId': {
       const nodes = flattenNodes(layout.root).filter(n => !selectedNodeId || n.id !== selectedNodeId)
       return { type: 'select', options: nodes.map(n => ({
         value: n.id,
@@ -465,7 +465,7 @@ export const getEditorType = (property: string, itemType?: string): FieldMeta['t
     case 'gap': case 'fontSize': case 'widthMm': case 'heightMm':
     case 'offsetX': case 'offsetY': case 'rotation': case 'scale': case 'strokeWidth': case 'cornerRadius':
     case 'columns': case 'repeatCount': case 'repeatOffsetX': case 'repeatOffsetY': return 'number'
-    case 'layout': case 'align': case 'verticalAlign': case 'font': case 'fit': case 'copyTargetId': return 'select'
+    case 'layout': case 'align': case 'verticalAlign': case 'font': case 'fit': case 'cloneTargetId': return 'select'
     default: return 'text'
   }
 }

--- a/src/components/layout/LayoutEditorPanel.tsx
+++ b/src/components/layout/LayoutEditorPanel.tsx
@@ -116,7 +116,7 @@ export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, 
     setSelectedNodeId(section.id)
   }
 
-  const handleAddItem = (itemType: 'text' | 'frame' | 'image' | 'emoji' | 'copy' | 'numbers') => {
+  const handleAddItem = (itemType: 'text' | 'frame' | 'image' | 'emoji' | 'clone' | 'numbers') => {
     const t = JSON.parse(JSON.stringify(layout))
     let parentId: string
     if (selectedKind === 'section' && selectedNodeId) parentId = selectedNodeId
@@ -132,7 +132,7 @@ export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, 
       frame: { ...base, type: 'frame', name: 'New Frame', strokeWidth: 2, cornerRadius: 8 },
       image: { ...base, type: 'image', name: 'New Image', fit: 'cover', cornerRadius: 0 },
       emoji: { ...base, type: 'emoji', name: 'Emoji', emoji: '⭐', fontSize: 32 },
-      copy: { ...base, type: 'copy', name: 'Copy' },
+      clone: { ...base, type: 'clone', name: 'Clone' },
       numbers: { ...base, type: 'numbers', name: 'New Numbers', fontSize: 20, align: 'right', defaultValue: '0' },
     }
     const item = items[itemType]

--- a/src/components/layout/NodeTree.tsx
+++ b/src/components/layout/NodeTree.tsx
@@ -11,7 +11,7 @@ type NodeTreeProps = {
   onSelectNode: (id: string) => void
   onDrop: (dragId: string, dragKind: 'section' | 'item', dropTargetId: string, position: 'before' | 'after' | 'inside') => void
   onAddSection?: () => void
-  onAddItem?: (type: 'text' | 'frame' | 'image' | 'emoji' | 'copy' | 'numbers') => void
+  onAddItem?: (type: 'text' | 'frame' | 'image' | 'emoji' | 'clone' | 'numbers') => void
   onDuplicate?: () => void
   onDelete?: () => void
   canDelete?: boolean
@@ -155,7 +155,7 @@ export default function NodeTree({ root, selectedNodeId, onSelectNode, onDrop, o
                 <button onClick={() => { onAddItem('frame'); close() }} className="flex items-center gap-2 w-full rounded px-3 py-1.5 text-left text-sm hover:bg-accent/50"><Frame className="h-3.5 w-3.5" /> Frame</button>
                 <button onClick={() => { onAddItem('image'); close() }} className="flex items-center gap-2 w-full rounded px-3 py-1.5 text-left text-sm hover:bg-accent/50"><Image className="h-3.5 w-3.5" /> Image</button>
                 <button onClick={() => { onAddItem('emoji'); close() }} className="flex items-center gap-2 w-full rounded px-3 py-1.5 text-left text-sm hover:bg-accent/50"><Smile className="h-3.5 w-3.5" /> Emoji</button>
-                <button onClick={() => { onAddItem('copy'); close() }} className="flex items-center gap-2 w-full rounded px-3 py-1.5 text-left text-sm hover:bg-accent/50"><Copy className="h-3.5 w-3.5" /> Copy</button>
+                <button onClick={() => { onAddItem('clone'); close() }} className="flex items-center gap-2 w-full rounded px-3 py-1.5 text-left text-sm hover:bg-accent/50"><Copy className="h-3.5 w-3.5" /> Clone</button>
               </>)}
             </PortalDropdown>
           )}
@@ -190,7 +190,7 @@ export default function NodeTree({ root, selectedNodeId, onSelectNode, onDrop, o
         const prefix = isSection ? (hasChildren ? (isCollapsed ? '▸' : '▾') : '▾') : '·'
         const iconClass = "h-3.5 w-3.5 inline-block opacity-60"
         const sectionIcons: Record<string, React.ReactNode> = { column: <Rows3 className={iconClass} />, row: <Columns3 className={iconClass} />, stack: <Layers className={iconClass} />, grid: <Grid3X3 className={iconClass} /> }
-        const itemIcons: Record<string, React.ReactNode> = { text: <Type className={iconClass} />, numbers: <Hash className={iconClass} />, frame: <Frame className={iconClass} />, image: <Image className={iconClass} />, emoji: <Smile className={iconClass} />, copy: <Copy className={iconClass} /> }
+        const itemIcons: Record<string, React.ReactNode> = { text: <Type className={iconClass} />, numbers: <Hash className={iconClass} />, frame: <Frame className={iconClass} />, image: <Image className={iconClass} />, emoji: <Smile className={iconClass} />, clone: <Copy className={iconClass} /> }
         const typeIcon = node.kind === 'section'
           ? sectionIcons[(node.obj as CardLayoutSection).layout] ?? null
           : itemIcons[(node.obj as any).type ?? 'text'] ?? null

--- a/src/components/layout/PropertyPanel.tsx
+++ b/src/components/layout/PropertyPanel.tsx
@@ -77,8 +77,8 @@ const EMOJI_PROPERTIES: PropertyDef[] = [
   { key: 'fontSize', label: 'Size' },
 ]
 
-const COPY_PROPERTIES: PropertyDef[] = [
-  { key: 'copyTargetId', label: 'Target' },
+const CLONE_PROPERTIES: PropertyDef[] = [
+  { key: 'cloneTargetId', label: 'Target' },
   { key: 'scale', label: 'Scale' },
 ]
 
@@ -91,7 +91,7 @@ const getPropertiesForNode = (kind: 'section' | 'item', node: any, isRoot: boole
     case 'frame': return [...COMMON_ITEM_PROPERTIES, ...FRAME_PROPERTIES]
     case 'image': return [...COMMON_ITEM_PROPERTIES, ...IMAGE_PROPERTIES]
     case 'emoji': return [...COMMON_ITEM_PROPERTIES, ...EMOJI_PROPERTIES]
-    case 'copy': return [...COMMON_ITEM_PROPERTIES.filter(p => p.key !== 'widthMm' && p.key !== 'heightMm'), ...COPY_PROPERTIES]
+    case 'clone': return [...COMMON_ITEM_PROPERTIES.filter(p => p.key !== 'widthMm' && p.key !== 'heightMm'), ...CLONE_PROPERTIES]
     default: return COMMON_ITEM_PROPERTIES
   }
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -93,7 +93,9 @@ const normalizeItem = (item: unknown, cardWidth: number, cardHeight: number): Ca
         : 20;
     // Determine item type - only if explicitly set
     const hasType = obj.type !== undefined && obj.type !== null && obj.type !== "";
-    const type = hasType ? safeEnum(obj.type, ["text", "frame", "image", "emoji", "copy", "numbers"] as const, "text" as const) : null;
+    // Migration: "copy" items were renamed to "clone"
+    const rawType = obj.type === "copy" ? "clone" : obj.type;
+    const type = hasType ? safeEnum(rawType, ["text", "frame", "image", "emoji", "clone", "numbers"] as const, "text" as const) : null;
     // Common base
     const base = {
         id,
@@ -144,12 +146,16 @@ const normalizeItem = (item: unknown, cardWidth: number, cardHeight: number): Ca
         };
         return emojiItem;
     }
-    if (type === "copy") {
+    if (type === "clone") {
+        // Migration: legacy "copy" items stored the target as copyTargetId
+        const cloneTargetId = typeof obj.cloneTargetId === 'string' ? obj.cloneTargetId
+            : typeof obj.copyTargetId === 'string' ? obj.copyTargetId
+            : undefined;
         return {
             ...base,
             bindings: normalizeBindings(obj),
-            type: "copy" as const,
-            copyTargetId: typeof obj.copyTargetId === 'string' ? obj.copyTargetId : undefined,
+            type: "clone" as const,
+            cloneTargetId,
             scale: obj.scale !== undefined && obj.scale !== null ? safeNumber(obj.scale, 1) : undefined,
         };
     }

--- a/src/render.ts
+++ b/src/render.ts
@@ -292,7 +292,7 @@ const computeLayoutPx = (layout: CardLayout): LayoutResult => {
   layoutSections(layout.root, rootRect, result);
   layoutItems(layout, result);
 
-  // Resize copy items to match their target's bounds * scale
+  // Resize clone items to match their target's bounds * scale
   const findItemInSection = (s: CardLayoutSection, id: string): CardLayoutItem | null => {
     for (const i of s.items) if (i.id === id) return i;
     for (const c of s.children) { const r = findItemInSection(c, id); if (r) return r; }
@@ -308,12 +308,12 @@ const computeLayoutPx = (layout: CardLayout): LayoutResult => {
     s.children.forEach(c => list.push(...getAllItemsInSection(c)));
     return list;
   };
-  const resizeCopyItems = (section: CardLayoutSection) => {
+  const resizeCloneItems = (section: CardLayoutSection) => {
     section.items.forEach((item) => {
-      if (item.type !== "copy") return;
-      const copyRect = result.items.get(item.id);
-      if (!copyRect) return;
-      const targetId = (item as any).copyTargetId;
+      if (item.type !== "clone") return;
+      const cloneRect = result.items.get(item.id);
+      if (!cloneRect) return;
+      const targetId = (item as any).cloneTargetId;
       if (!targetId) return;
       const targetItem = findItemInSection(layout.root, targetId);
       const targetSection = targetItem ? null : findSectionInRoot(layout.root, targetId);
@@ -331,20 +331,22 @@ const computeLayoutPx = (layout: CardLayout): LayoutResult => {
       const w = (bounds.x2 - bounds.x) * scale;
       const h = (bounds.y2 - bounds.y) * scale;
       // Reposition based on anchor
-      copyRect.width = w;
-      copyRect.height = h;
+      cloneRect.width = w;
+      cloneRect.height = h;
       const attachTarget = item.attach.targetType === "item"
         ? result.items.get(item.attach.targetId)
         : result.sections.get(item.attach.targetId);
       if (attachTarget) {
         const target = anchorPosition(attachTarget, item.attach.anchor);
-        copyRect.x = target.x - w * item.anchor.x;
-        copyRect.y = target.y - h * item.anchor.y;
+        const ox = mmToPx((item as any).offsetX ?? 0);
+        const oy = mmToPx((item as any).offsetY ?? 0);
+        cloneRect.x = target.x - w * item.anchor.x + ox;
+        cloneRect.y = target.y - h * item.anchor.y + oy;
       }
     });
-    section.children.forEach(resizeCopyItems);
+    section.children.forEach(resizeCloneItems);
   };
-  resizeCopyItems(layout.root);
+  resizeCloneItems(layout.root);
 
   return result;
 };
@@ -488,8 +490,8 @@ export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: Ren
         return wrapRotation(`<text x="${textX}" y="${textY}" text-anchor="middle" dominant-baseline="central" font-size="${fontSize}" fill="#000000">${escape(emoji)}</text>`);
       }
 
-      if (itemType === "copy") {
-        const targetId = (item as any).copyTargetId;
+      if (itemType === "clone") {
+        const targetId = (item as any).cloneTargetId;
         if (!targetId) return "";
         const targetItem = findItem(layout.root, targetId);
         const targetSection = targetItem ? null : findSection(layout.root, targetId);
@@ -542,7 +544,7 @@ export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: Ren
       }
 
       // Render text/numbers item (default) - type guard
-      if (item.type === "frame" || item.type === "image" || item.type === "emoji" || item.type === "copy") return "";
+      if (item.type === "frame" || item.type === "image" || item.type === "emoji" || item.type === "clone") return "";
       const isNumbers = item.type === "numbers";
       const value = String(resolve(item, "defaultValue", card, layoutMm) ?? "");
       if (!value) return "";
@@ -696,8 +698,8 @@ export const renderLayoutSvg = (layoutMm: CardLayout, options: {
       const textY = rect.y + rect.height / 2;
       return wrapRot(`<text x="${textX}" y="${textY}" text-anchor="middle" dominant-baseline="central" font-size="${fontSize}" fill="#000000">${escape(emoji)}</text>`);
     }
-    if (itemType === "copy") {
-      const targetId = (item as any).copyTargetId;
+    if (itemType === "clone") {
+      const targetId = (item as any).cloneTargetId;
       if (!targetId) return "";
       const targetItem = findItem(layout.root, targetId);
       const targetSection = targetItem ? null : findSection(layout.root, targetId);
@@ -750,7 +752,7 @@ export const renderLayoutSvg = (layoutMm: CardLayout, options: {
       parts.push(`</g>`);
       return wrapRot(parts.join(""));
     }
-    if (item.type === "frame" || item.type === "image" || item.type === "emoji" || item.type === "copy") return "";
+    if (item.type === "frame" || item.type === "image" || item.type === "emoji" || item.type === "clone") return "";
     const isNumbers = item.type === "numbers";
     const value = String(resolve(item, "defaultValue", emptyCard, layoutMm) ?? "");
     if (!value) return "";

--- a/src/render/cardSvg.ts
+++ b/src/render/cardSvg.ts
@@ -274,7 +274,7 @@ export const computeLayout = (layout: CardLayout): LayoutResult => {
   layoutSections(layout.root, rootRect, result);
   layoutItems(layout, result);
 
-  // Resize copy items to match their target's bounds * scale
+  // Resize clone items to match their target's bounds * scale
   const findItemIn = (s: CardLayoutSection, id: string): CardLayoutItem | null => {
     for (const i of s.items) if (i.id === id) return i;
     for (const c of s.children) { const r = findItemIn(c, id); if (r) return r; }
@@ -290,12 +290,12 @@ export const computeLayout = (layout: CardLayout): LayoutResult => {
     s.children.forEach(c => list.push(...getAllItemsIn(c)));
     return list;
   };
-  const resizeCopyItems = (section: CardLayoutSection) => {
+  const resizeCloneItems = (section: CardLayoutSection) => {
     section.items.forEach((item) => {
-      if (item.type !== "copy") return;
-      const copyRect = result.items.get(item.id);
-      if (!copyRect) return;
-      const targetId = (item as any).copyTargetId;
+      if (item.type !== "clone") return;
+      const cloneRect = result.items.get(item.id);
+      if (!cloneRect) return;
+      const targetId = (item as any).cloneTargetId;
       if (!targetId) return;
       const targetItem = findItemIn(layout.root, targetId);
       const targetSection = targetItem ? null : findSectionIn(layout.root, targetId);
@@ -312,20 +312,22 @@ export const computeLayout = (layout: CardLayout): LayoutResult => {
       const scale = (item as any).scale ?? 1;
       const w = (bounds.x2 - bounds.x) * scale;
       const h = (bounds.y2 - bounds.y) * scale;
-      copyRect.width = w;
-      copyRect.height = h;
+      cloneRect.width = w;
+      cloneRect.height = h;
       const attachTarget = item.attach.targetType === "item"
         ? result.items.get(item.attach.targetId)
         : result.sections.get(item.attach.targetId);
       if (attachTarget) {
         const target = anchorPosition(attachTarget, item.attach.anchor);
-        copyRect.x = target.x - w * item.anchor.x;
-        copyRect.y = target.y - h * item.anchor.y;
+        const ox = mmToPx((item as any).offsetX ?? 0);
+        const oy = mmToPx((item as any).offsetY ?? 0);
+        cloneRect.x = target.x - w * item.anchor.x + ox;
+        cloneRect.y = target.y - h * item.anchor.y + oy;
       }
     });
-    section.children.forEach(resizeCopyItems);
+    section.children.forEach(resizeCloneItems);
   };
-  resizeCopyItems(layout.root);
+  resizeCloneItems(layout.root);
 
   return result;
 };
@@ -498,8 +500,8 @@ export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: Ren
       pushEl(`<text x="${textX}" y="${textY}" text-anchor="middle" dominant-baseline="central" font-size="${fontSize}" fill="#000000">${escape(emoji)}</text>`);
     }
 
-    if (itemType === "copy") {
-      const targetId = (item as any).copyTargetId;
+    if (itemType === "clone") {
+      const targetId = (item as any).cloneTargetId;
       if (!targetId) return;
       // Find target items: either a single item or all items in a section
       const targetItem = findItem(layout.root, targetId);
@@ -661,8 +663,8 @@ export const renderLayoutSvg = (layoutMm: CardLayout, options: {
       const textY = rect.y + rect.height / 2;
       return wrapRot(`<text x="${textX}" y="${textY}" text-anchor="middle" dominant-baseline="central" font-size="${fontSize}" fill="#000000">${escape(emoji)}</text>`);
     }
-    if (itemType === "copy") {
-      const targetId = (item as any).copyTargetId;
+    if (itemType === "clone") {
+      const targetId = (item as any).cloneTargetId;
       if (!targetId) return "";
       const targetItem = findItem(layout.root, targetId);
       const targetSection = targetItem ? null : findSection(layout.root, targetId);
@@ -715,7 +717,7 @@ export const renderLayoutSvg = (layoutMm: CardLayout, options: {
       parts.push(`</g>`);
       return wrapRot(parts.join(""));
     }
-    if (item.type === "frame" || item.type === "image" || item.type === "emoji" || item.type === "copy") return "";
+    if (item.type === "frame" || item.type === "image" || item.type === "emoji" || item.type === "clone") return "";
     const isNumbers = item.type === "numbers";
     const value = String(resolve(item, "defaultValue", emptyCard, layoutMm) ?? "");
     if (!value) return "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,10 +67,11 @@ export type CardLayoutEmojiItem = CardLayoutItemBase & {
   fontSize: number;
 };
 
-// Copy item - renders the same content as another item or section's items
-export type CardLayoutCopyItem = CardLayoutItemBase & {
-  type: "copy";
-  copyTargetId?: string;
+// Clone item - renders the same content as another item or section's items
+// (formerly "copy"; the normalizer migrates legacy data)
+export type CardLayoutCloneItem = CardLayoutItemBase & {
+  type: "clone";
+  cloneTargetId?: string;
   scale?: number;
 };
 
@@ -92,7 +93,7 @@ export type CardLayoutItem =
   | CardLayoutFrameItem
   | CardLayoutImageItem
   | CardLayoutEmojiItem
-  | CardLayoutCopyItem
+  | CardLayoutCloneItem
   | CardLayoutNumbersItem;
 
 export type CardLayoutSection = {

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -564,6 +564,10 @@ async function createFullTestGame(storage) {
             fontSize: 22, align: "right", verticalAlign: "middle", color: "#222",
             anchor: { x: 1, y: 0 }, attach: { targetType: "section", targetId: "body", anchor: { x: 1, y: 0 } },
             widthMm: 25, heightMm: 12 },
+          { id: "mini-title", name: "Mini Title", type: "clone", cloneTargetId: "title-item",
+            scale: 0.5, offsetX: 2.5, offsetY: -1.5,
+            anchor: { x: 0.5, y: 1 }, attach: { targetType: "section", targetId: "body", anchor: { x: 0.5, y: 0.5 } },
+            widthMm: 30, heightMm: 10 },
         ],
       },
     ],
@@ -613,7 +617,7 @@ async function verifyFullTestGame(storage, gameId) {
   const items = [];
   function collect(s) { items.push(...(s.items || [])); (s.children || []).forEach(collect); }
   collect(tpl.root);
-  assert.equal(items.length, 6, `expected 6 items, got ${items.length}: ${items.map(i => i.name).join(", ")}`);
+  assert.equal(items.length, 7, `expected 7 items, got ${items.length}: ${items.map(i => i.name).join(", ")}`);
 
   // Text item
   const title = items.find(i => i.id === "title-item");
@@ -654,6 +658,14 @@ async function verifyFullTestGame(storage, gameId) {
   const desc = items.find(i => i.id === "desc-item");
   assert.ok(desc); assert.equal(desc.attach.targetType, "item");
   assert.equal(desc.attach.targetId, "art-item");
+
+  // Clone item
+  const mini = items.find(i => i.id === "mini-title");
+  assert.ok(mini); assert.equal(mini.type, "clone");
+  assert.equal(mini.cloneTargetId, "title-item");
+  assert.equal(mini.scale, 0.5);
+  assert.equal(mini.offsetX, 2.5, "clone offsetX must survive the round trip");
+  assert.equal(mini.offsetY, -1.5, "clone offsetY must survive the round trip");
 
   // Numbers item
   const score = items.find(i => i.id === "score-item");

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -431,3 +431,31 @@ test("normalizeLayout handles anchor point rounding", () => {
   assert.equal(item.attach.anchor.x, 0.5);
   assert.equal(item.attach.anchor.y, 0.5);
 });
+
+test("normalizeLayout migrates legacy copy items to clone", () => {
+  const layout = normalizeLayout({
+    id: "l", name: "L", width: 63.5, height: 88.9, radius: 2, bleed: 1,
+    root: {
+      id: "root", name: "Root", layout: "stack", sizePct: 100, gap: 0, children: [],
+      items: [
+        { id: "legacy", name: "Legacy", type: "copy", copyTargetId: "t1", scale: 2,
+          offsetX: 3, offsetY: -2,
+          anchor: { x: 0.5, y: 0.5 },
+          attach: { targetType: "section", targetId: "root", anchor: { x: 0.5, y: 0.5 } },
+          widthMm: 30, heightMm: 20 },
+        { id: "current", name: "Current", type: "clone", cloneTargetId: "t2",
+          anchor: { x: 0.5, y: 0.5 },
+          attach: { targetType: "section", targetId: "root", anchor: { x: 0.5, y: 0.5 } },
+          widthMm: 30, heightMm: 20 },
+      ]
+    }
+  });
+  const [legacy, current] = layout.root.items;
+  assert.equal(legacy.type, "clone");
+  assert.equal(legacy.cloneTargetId, "t1");
+  assert.equal(legacy.scale, 2);
+  assert.equal(legacy.offsetX, 3);
+  assert.equal(legacy.offsetY, -2);
+  assert.equal(current.type, "clone");
+  assert.equal(current.cloneTargetId, "t2");
+});

--- a/test/rendererParity.test.js
+++ b/test/rendererParity.test.js
@@ -101,3 +101,24 @@ test("both renderers use the same text fontSize fallback", () => {
   assert.equal(sizeOf(a), sizeOf(b), "fallback font size must match between renderers");
   assert.equal(sizeOf(a), "16", "fallback must match the normalizer default");
 });
+
+test("both renderers apply offsets to clone items", () => {
+  const PX_PER_MM = 300 / 25.4;
+  const cloneItem = (extra = {}) => ({
+    id: "cl1", name: "Clone", type: "clone", cloneTargetId: "f1", scale: 1,
+    anchor: { x: 0.5, y: 0.5 }, attach: { targetType: "section", targetId: "root", anchor: { x: 0.5, y: 0.5 } },
+    widthMm: 40, heightMm: 20,
+    ...extra,
+  });
+  const translateOf = (svg) => {
+    const m = svg.match(/<g transform="translate\((-?[\d.]+),(-?[\d.]+)\) scale\(/);
+    return m ? { x: Number(m[1]), y: Number(m[2]) } : null;
+  };
+  for (const render of [renderApp, renderServer]) {
+    const base = translateOf(render(card(), layoutWith([frame(), cloneItem()])));
+    const shifted = translateOf(render(card(), layoutWith([frame(), cloneItem({ offsetX: 10, offsetY: 5 })])));
+    assert.ok(base && shifted, "clone items must render a translated group");
+    assert.equal(Math.round(shifted.x - base.x), Math.round(10 * PX_PER_MM), "offsetX must shift the clone");
+    assert.equal(Math.round(shifted.y - base.y), Math.round(5 * PX_PER_MM), "offsetY must shift the clone");
+  }
+});


### PR DESCRIPTION
## Bug fix: offsets had no effect on copy/clone items

`placeItem` applies `offsetX`/`offsetY`, but the copy item's post-layout pass (`resizeCopyItems`) then recomputed the rect's position from the attach anchor **without** re-applying the offsets — so they were silently overwritten. Both renderers (`src/render.ts` and `src/render/cardSvg.ts`) now re-apply the offsets when repositioning the resized clone rect.

## Rename: `copy` → `clone`

- `CardLayoutCloneItem` with `type: "clone"` and `cloneTargetId` (was `CardLayoutCopyItem` / `"copy"` / `copyTargetId`)
- UI updated: add-item menu, node tree icon map, property panel (`CLONE_PROPERTIES`), control panel editors
- **Migration**: `normalizeLayout` maps legacy `type: "copy"` to `"clone"` and reads `copyTargetId` into `cloneTargetId`, so existing layouts keep working on every backend (localFile, indexedDB, S3, Google Drive, zip import) since they all load through the normalizer

## Tests

- `rendererParity.test.js`: both renderers must shift a clone's rendered group by `mmToPx(offset)` (fails without the fix)
- `normalize.test.js`: legacy `copy`/`copyTargetId` items migrate to `clone`/`cloneTargetId`, offsets and scale preserved
- `backendCompat.test.js`: the round-trip test game now includes a clone item with `cloneTargetId`, `scale`, `offsetX`, `offsetY`

`tsc --noEmit` clean, all 200 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUxLYQo4pA8WzbgeCPV7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUxLYQo4pA8WzbgeCPV7Mh)_