### PR TITLE
Add a flip button to the preview toolbar to show the card back

### DIFF
--- a/src/components/LayoutPreview.tsx
+++ b/src/components/LayoutPreview.tsx
@@ -15,6 +15,8 @@ type LayoutPreviewProps = {
   gameFonts?: Record<string, { name: string; file: string }>
   selectedNodeId?: string | null
   onNodeClick?: (id: string) => void
+  /** Rendered image of the card's other face — enables the flip button. */
+  flipImage?: string
 }
 
 function CardPicker({ cards, value, onChange }: { cards: PreviewCard[]; value: string | null; onChange: (id: string | null) => void }) {
@@ -55,7 +57,7 @@ function CardPicker({ cards, value, onChange }: { cards: PreviewCard[]; value: s
   )
 }
 
-export default function LayoutPreview({ layout, gameId, cards = [], gameFonts, selectedNodeId, onNodeClick }: LayoutPreviewProps) {
+export default function LayoutPreview({ layout, gameId, cards = [], gameFonts, selectedNodeId, onNodeClick, flipImage }: LayoutPreviewProps) {
   const [showSections, setShowSections] = useState(true)
   const [showItemWires, setShowItemWires] = useState(true)
   const [previewCardId, setPreviewCardId] = useState<string | null>(null)
@@ -106,6 +108,8 @@ export default function LayoutPreview({ layout, gameId, cards = [], gameFonts, s
       hitAreas={hitAreas}
       selectedHitAreaId={selectedNodeId}
       onHitAreaClick={onNodeClick}
+      backImage={flipImage}
+      backFit="fill"
       extraButtons={<>
         {cards.length > 0 && <span className="mr-1"><CardPicker cards={cards} value={previewCardId} onChange={setPreviewCardId} /></span>}
         <button

--- a/src/components/ZoomablePreview.tsx
+++ b/src/components/ZoomablePreview.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { Lock, Unlock, Home, Box } from 'lucide-react'
+import { Lock, Unlock, Home, Box, FlipHorizontal2 } from 'lucide-react'
 import useAssetUrl from '../hooks/useAssetUrl'
 import CollapsibleHeader, { useCollapsible } from '@/components/ui/CollapsibleHeader'
 
@@ -29,6 +29,7 @@ export default function ZoomablePreview({ src, alt, svgWidth, svgHeight, hitArea
   const { collapsed: panelCollapsed, toggle: togglePanel } = useCollapsible()
   const [view, setView] = useState<ViewState>({ scale: 1, x: 0, y: 0 })
   const [unlocked, setUnlocked] = useState(false)
+  const [flipped, setFlipped] = useState(false)
   const [mode3d, setMode3d] = useState(false)
   const [rotation, setRotation] = useState<Rotation>({ x: 0, y: 0 })
   const [zoom3d, setZoom3d] = useState(1)
@@ -98,7 +99,8 @@ export default function ZoomablePreview({ src, alt, svgWidth, svgHeight, hitArea
   }, [view.x, view.y, view.scale, unlocked, mode3d, rotation.x, rotation.y, zoom3d])
 
   const handleClick = useCallback((e: React.MouseEvent) => {
-    if (unlocked || !hitAreas?.length || !onHitAreaClick || !svgWidth || !svgHeight) return
+    // Hit areas describe the front face — ignore clicks while showing the back.
+    if (flipped || unlocked || !hitAreas?.length || !onHitAreaClick || !svgWidth || !svgHeight) return
     const container = containerRef.current
     if (!container) return
     const img = container.querySelector('img')
@@ -114,7 +116,7 @@ export default function ZoomablePreview({ src, alt, svgWidth, svgHeight, hitArea
     const currentIdx = sorted.findIndex(a => a.id === selectedHitAreaId)
     const hit = sorted[(currentIdx + 1) % sorted.length]
     if (hit) onHitAreaClick(hit.id)
-  }, [unlocked, hitAreas, selectedHitAreaId, onHitAreaClick, svgWidth, svgHeight])
+  }, [flipped, unlocked, hitAreas, selectedHitAreaId, onHitAreaClick, svgWidth, svgHeight])
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     if (!pointersRef.current.has(e.pointerId)) return
@@ -180,6 +182,16 @@ export default function ZoomablePreview({ src, alt, svgWidth, svgHeight, hitArea
     })
   }, [])
 
+  // In 2D the flip button swaps which face is displayed; in 3D it spins the
+  // card half a turn so the back comes around.
+  const handleFlip = useCallback(() => {
+    if (mode3d) {
+      setRotation(prev => ({ ...prev, y: prev.y + 180 }))
+      return
+    }
+    setFlipped(prev => !prev)
+  }, [mode3d])
+
   const CARD_DEPTH = 4
   const checkerboard = { backgroundImage: 'repeating-conic-gradient(#e5e5e5 0% 25%, transparent 0% 50%)', backgroundSize: '16px 16px' }
 
@@ -188,6 +200,19 @@ export default function ZoomablePreview({ src, alt, svgWidth, svgHeight, hitArea
       <CollapsibleHeader collapsed={panelCollapsed} onToggle={togglePanel}>
         <div className="ml-auto flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
           {extraButtons}
+          {backImage && (
+            <button
+              onClick={handleFlip}
+              className={`rounded p-1 transition-colors ${
+                flipped && !mode3d
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              title={mode3d ? 'Flip card' : flipped ? 'Show front' : 'Show back'}
+            >
+              <FlipHorizontal2 className="h-4 w-4" />
+            </button>
+          )}
           <button
             onClick={toggle3d}
             className={`rounded p-1 transition-colors ${
@@ -381,8 +406,8 @@ export default function ZoomablePreview({ src, alt, svgWidth, svgHeight, hitArea
           )
         })() : (
           <img
-            src={resolvedSrc}
-            alt={alt}
+            src={flipped && resolvedBack ? resolvedBack : resolvedSrc}
+            alt={flipped && resolvedBack ? `${alt} (back)` : alt}
             className={`max-w-full block mx-auto select-none transition-opacity duration-200 drop-shadow-lg ${imgLoaded ? 'opacity-100' : 'opacity-0 h-0'}`}
             draggable={false}
             onLoad={() => setImgLoaded(true)}

--- a/src/components/layout/LayoutEditorPanel.tsx
+++ b/src/components/layout/LayoutEditorPanel.tsx
@@ -15,9 +15,11 @@ type LayoutEditorPanelProps = {
   gameImages?: { file: string; url: string; name: string }[]
   onUploadFile: (file: File) => Promise<string>
   cards?: PreviewCard[]
+  /** Rendered image of the card's other face — enables the preview's flip button. */
+  flipImage?: string
 }
 
-export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, gameFonts, gameImages, onUploadFile, cards }: LayoutEditorPanelProps) {
+export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, gameFonts, gameImages, onUploadFile, cards, flipImage }: LayoutEditorPanelProps) {
   // Local working copy for instant feedback; debounced save to backend
   const [workingLayout, setWorkingLayout] = useState(propLayout)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout>>(null)
@@ -222,6 +224,7 @@ export default function LayoutEditorPanel({ layout: propLayout, onSave, gameId, 
         gameFonts={gameFonts}
         selectedNodeId={selectedNodeId}
         onNodeClick={handleNodeSelect}
+        flipImage={flipImage}
       />
     </>
   )

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -1349,6 +1349,7 @@ export default function GameEditorPage() {
                     return await uploadImageMut.mutateAsync(file)
                   }}
                   cards={cards}
+                  flipImage={backPreview || undefined}
                 />
               )}
             </div>
@@ -1389,6 +1390,7 @@ export default function GameEditorPage() {
                     return await uploadImageMut.mutateAsync(file)
                   }}
                   cards={cards}
+                  flipImage={cardPreview || undefined}
                 />
               ) : (
                 <div className="md:col-span-2 flex items-center justify-center rounded-lg border bg-card p-8">


### PR DESCRIPTION
## Summary

Follow-up to #62/#66/#72. The renderer toolbar (`ZoomablePreview`'s button bar) gains a **flip button** to show the card's back:

- The button appears whenever a back image is available, next to the 3D/reset/lock buttons.
- **2D mode**: flipping swaps the displayed face; clicking hit areas is disabled while the back is shown (they describe the front face). Pan/zoom keeps working on either face.
- **3D mode**: the button spins the card half a turn so the back comes around with the existing 3D animation.

## Where it shows up

- **Cards tab** preview: already fed the rendered back — gets the button with no wiring.
- **Front tab** layout editor preview: flips to the rendered back of the selected card (new `flipImage` prop threaded through `LayoutEditorPanel` → `LayoutPreview`).
- **Back tab** layout editor preview: flips to the rendered front — each editor shows the card's other face.

## Testing

- `tsc`, the production build, and the test suite pass (one unrelated flaky teardown in `serverSecurity.test.js` — `ENOTEMPTY` on temp-dir cleanup — passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8)_