### PR TITLE
Add text effects (outline, shadow, line height, letter spacing) and fix alpha mask

### DIFF
--- a/src/components/layout/ControlPanel.tsx
+++ b/src/components/layout/ControlPanel.tsx
@@ -74,6 +74,11 @@ const getFieldMeta = (property: string, layout: CardLayout, selectedNodeId?: str
     case 'scale': return { type: 'number', min: 0.1, max: 10, step: 0.1, hardMin: true }
     case 'strokeWidth': return { type: 'number', min: 0, max: 20, step: 0.5, hardMin: true }
     case 'cornerRadius': return { type: 'number', min: 0, max: 100, step: 1, hardMin: true }
+    case 'shadowOffsetX': return { type: 'number', min: -20, max: 20, step: 0.5 }
+    case 'shadowOffsetY': return { type: 'number', min: -20, max: 20, step: 0.5 }
+    case 'shadowBlur': return { type: 'number', min: 0, max: 50, step: 0.5, hardMin: true }
+    case 'lineHeight': return { type: 'number', min: 0.5, max: 3, step: 0.05, hardMin: true }
+    case 'letterSpacing': return { type: 'number', min: -10, max: 50, step: 0.5 }
     case 'layout': return { type: 'select', options: [
       { value: 'row', label: 'Row' },
       { value: 'column', label: 'Column' },
@@ -118,6 +123,7 @@ const getFieldMeta = (property: string, layout: CardLayout, selectedNodeId?: str
     }
     case 'color':
     case 'strokeColor':
+    case 'shadowColor':
     case 'fillColor': return { type: 'color' }
     case 'defaultValue': {
       if (selectedNodeId) {
@@ -473,13 +479,14 @@ function ImageUploadEditor({ value, onChange, aspectRatio, gameImages, onUploadF
 export const getEditorType = (property: string, itemType?: string): FieldMeta['type'] => {
   switch (property) {
     case 'emoji': return 'emoji'
-    case 'color': case 'strokeColor': case 'fillColor': return 'color'
+    case 'color': case 'strokeColor': case 'shadowColor': case 'fillColor': return 'color'
     case 'visible': case 'flipH': case 'flipV': return 'boolean'
     case 'defaultValue': return itemType === 'image' ? 'image-upload' : 'richtext'
     case 'maskUrl': return 'image-upload'
     case 'width': case 'height': case 'radius': case 'bleed': case 'sizePct': case 'opacity':
     case 'gap': case 'fontSize': case 'widthMm': case 'heightMm':
     case 'offsetX': case 'offsetY': case 'rotation': case 'scale': case 'strokeWidth': case 'cornerRadius':
+    case 'shadowOffsetX': case 'shadowOffsetY': case 'shadowBlur': case 'lineHeight': case 'letterSpacing':
     case 'columns': case 'repeatCount': case 'repeatOffsetX': case 'repeatOffsetY': return 'number'
     case 'layout': case 'align': case 'verticalAlign': case 'font': case 'fit': case 'cloneTargetId': case 'blendMode': return 'select'
     default: return 'text'

--- a/src/components/layout/PropertyPanel.tsx
+++ b/src/components/layout/PropertyPanel.tsx
@@ -62,6 +62,14 @@ const TEXT_PROPERTIES: PropertyDef[] = [
   { key: 'verticalAlign', label: 'V Align' },
   { key: 'font', label: 'Font' },
   { key: 'color', label: 'Color' },
+  { key: 'strokeWidth', label: 'Outline Width' },
+  { key: 'strokeColor', label: 'Outline Color' },
+  { key: 'shadowColor', label: 'Shadow Color' },
+  { key: 'shadowOffsetX', label: 'Shadow X' },
+  { key: 'shadowOffsetY', label: 'Shadow Y' },
+  { key: 'shadowBlur', label: 'Shadow Blur' },
+  { key: 'lineHeight', label: 'Line Height' },
+  { key: 'letterSpacing', label: 'Letter Spacing' },
 ]
 
 const FRAME_PROPERTIES: PropertyDef[] = [

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -73,6 +73,18 @@ const normalizeBindings = (obj: Record<string, unknown>): Record<string, Propert
 let fallbackIdCounter = 0;
 const fallbackId = (prefix: string): string => `${prefix}-${Date.now()}-${fallbackIdCounter++}`;
 
+/** Optional text-effect fields shared by text and numbers items. */
+const normalizeTextEffects = (obj: Record<string, unknown>) => ({
+    strokeColor: obj.strokeColor !== undefined && obj.strokeColor !== null && obj.strokeColor !== "" ? safeString(obj.strokeColor, "#000000") : undefined,
+    strokeWidth: obj.strokeWidth !== undefined && obj.strokeWidth !== null ? safeNumber(obj.strokeWidth, 0) : undefined,
+    shadowColor: obj.shadowColor !== undefined && obj.shadowColor !== null && obj.shadowColor !== "" ? safeString(obj.shadowColor, "#000000") : undefined,
+    shadowOffsetX: obj.shadowOffsetX !== undefined && obj.shadowOffsetX !== null ? safeNumber(obj.shadowOffsetX, 0) : undefined,
+    shadowOffsetY: obj.shadowOffsetY !== undefined && obj.shadowOffsetY !== null ? safeNumber(obj.shadowOffsetY, 0) : undefined,
+    shadowBlur: obj.shadowBlur !== undefined && obj.shadowBlur !== null ? safeNumber(obj.shadowBlur, 0) : undefined,
+    lineHeight: obj.lineHeight !== undefined && obj.lineHeight !== null ? safeNumber(obj.lineHeight, 0) : undefined,
+    letterSpacing: obj.letterSpacing !== undefined && obj.letterSpacing !== null ? safeNumber(obj.letterSpacing, 0) : undefined,
+});
+
 const normalizeItem = (item: unknown, cardWidth: number, cardHeight: number): CardLayoutItem => {
     const obj = item && typeof item === "object" ? item as Record<string, unknown> : {};
     // Base properties
@@ -176,6 +188,7 @@ const normalizeItem = (item: unknown, cardWidth: number, cardHeight: number): Ca
             verticalAlign: safeEnum(obj.verticalAlign, ["top", "middle", "bottom"] as const, "middle" as const),
             font: obj.font !== undefined && obj.font !== null && obj.font !== "" ? safeString(obj.font, "body") : undefined,
             color: safeString(obj.color, "#000000"),
+            ...normalizeTextEffects(obj),
         };
         return numbersItem;
     }
@@ -190,6 +203,7 @@ const normalizeItem = (item: unknown, cardWidth: number, cardHeight: number): Ca
         verticalAlign: safeEnum(obj.verticalAlign, ["top", "middle", "bottom"] as const, "middle" as const),
         font: obj.font !== undefined && obj.font !== null && obj.font !== "" ? safeString(obj.font, "body") : undefined,
         color: safeString(obj.color, "#000000"),
+        ...normalizeTextEffects(obj),
     };
     return textItem;
 };

--- a/src/render/cardSvg.ts
+++ b/src/render/cardSvg.ts
@@ -23,6 +23,7 @@ type RenderOptions = {
   fontSlots?: Record<string, FontSlot>;
   back?: string;
   backFit?: "cover" | "contain" | "fill";
+  svgTextOnly?: boolean;
 };
 
 export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: RenderOptions = {}): string =>
@@ -32,4 +33,5 @@ export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: Ren
     backFit: options.backFit,
     fonts: options.fontSlots,
     embedFonts: options.fonts,
+    svgTextOnly: options.svgTextOnly,
   });

--- a/src/render/core.ts
+++ b/src/render/core.ts
@@ -188,7 +188,10 @@ const itemEffects = (get: (prop: string) => unknown, rotation: number): ItemEffe
 /** Wrap an item's SVG in a <g> carrying its effects. Mask definitions are
  *  appended to `defs` (hoisted into <defs> by the callers). The mask is
  *  declared in the item's untransformed rect space, so it follows the item
- *  through rotation/flip. */
+ *  through rotation/flip. Masks use SVG's default luminance mode (white =
+ *  visible, black = hidden, transparency also hides) so ordinary gallery
+ *  images work — an alpha-type mask has no effect with images that carry
+ *  no alpha channel (JPEG, flat PNG). */
 const wrapItemEffects = (svg: string, itemId: string, rect: Rect, eff: ItemEffects, defs: string[]): string => {
   if (!svg) return svg;
   const cx = rect.x + rect.width / 2;
@@ -202,11 +205,68 @@ const wrapItemEffects = (svg: string, itemId: string, rect: Rect, eff: ItemEffec
   if (eff.blendMode) attrs.push(`style="mix-blend-mode:${eff.blendMode}"`);
   if (eff.maskUrl) {
     const maskId = `mask-${String(itemId).replace(/[^a-zA-Z0-9-_]/g, "")}`;
-    defs.push(`<mask id="${maskId}" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}"><image x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}" href="${escape(eff.maskUrl)}" preserveAspectRatio="none" /></mask>`);
+    defs.push(`<mask id="${maskId}" maskUnits="userSpaceOnUse" x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}"><image x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}" href="${escape(eff.maskUrl)}" preserveAspectRatio="none" /></mask>`);
     attrs.push(`mask="url(#${maskId})"`);
   }
   if (!attrs.length) return svg;
   return `<g ${attrs.join(" ")}>${svg}</g>`;
+};
+
+type TextEffects = {
+  strokeColor: string;
+  strokeWidth: number;
+  /** Empty string means no shadow. */
+  shadowColor: string;
+  shadowX: number;
+  shadowY: number;
+  shadowBlur: number;
+  /** 0 means unset (browser/renderer default). */
+  lineHeight: number;
+  letterSpacing: number;
+};
+
+/** Gather text effects; values are escaped here so both emitters can
+ *  interpolate them directly. */
+const textEffects = (get: (prop: string) => unknown): TextEffects => {
+  const rawShadow = get("shadowColor");
+  const shadowColor = rawShadow === undefined || rawShadow === null || rawShadow === "" || rawShadow === "none"
+    ? ""
+    : escape(String(rawShadow));
+  return {
+    strokeColor: escape(String(get("strokeColor") ?? "#000000")),
+    strokeWidth: Math.max(0, num(get("strokeWidth"), 0)),
+    shadowColor,
+    shadowX: num(get("shadowOffsetX"), 2),
+    shadowY: num(get("shadowOffsetY"), 2),
+    shadowBlur: Math.max(0, num(get("shadowBlur"), 2)),
+    lineHeight: Math.max(0, num(get("lineHeight"), 0)),
+    letterSpacing: num(get("letterSpacing"), 0),
+  };
+};
+
+/** CSS for the foreignObject text path. Only set properties are emitted so
+ *  untouched layouts render byte-identically. */
+const textEffectCss = (fx: TextEffects): string => {
+  let css = "";
+  if (fx.strokeWidth > 0) css += `-webkit-text-stroke:${fx.strokeWidth}px ${fx.strokeColor};paint-order:stroke;`;
+  if (fx.shadowColor) css += `text-shadow:${fx.shadowX}px ${fx.shadowY}px ${fx.shadowBlur}px ${fx.shadowColor};`;
+  if (fx.lineHeight > 0) css += `line-height:${fx.lineHeight};`;
+  if (fx.letterSpacing) css += `letter-spacing:${fx.letterSpacing}px;`;
+  return css;
+};
+
+/** Attributes for the svgTextOnly <text> path. A drop shadow needs a filter,
+ *  appended to `defs` (CSS blur radius ≈ 2× the Gaussian stdDeviation). */
+const textEffectAttrs = (fx: TextEffects, itemId: string, defs: string[]): string => {
+  let attrs = "";
+  if (fx.strokeWidth > 0) attrs += ` stroke="${fx.strokeColor}" stroke-width="${fx.strokeWidth}" stroke-linejoin="round" paint-order="stroke"`;
+  if (fx.letterSpacing) attrs += ` letter-spacing="${fx.letterSpacing}"`;
+  if (fx.shadowColor) {
+    const filterId = `shadow-${String(itemId).replace(/[^a-zA-Z0-9-_]/g, "")}`;
+    defs.push(`<filter id="${filterId}" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="${fx.shadowX}" dy="${fx.shadowY}" stdDeviation="${fx.shadowBlur / 2}" flood-color="${fx.shadowColor}" /></filter>`);
+    attrs += ` filter="url(#${filterId})"`;
+  }
+  return attrs;
 };
 
 const textAnchorFor = (align: string): string => {
@@ -633,18 +693,19 @@ export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: Ren
     const vAlign = ["top", "middle", "bottom"].includes(vAlignRaw) ? vAlignRaw : "middle";
     // Resolved values can come from card fields — escape before interpolating.
     const color = escape(String(resolve(item, "color", card, layoutMm) ?? palette.ink));
+    const fx = textEffects((p) => resolve(item, p, card, layoutMm));
     const styledLines = parseRichText(value);
     if (options.svgTextOnly) {
       const tabularAttr = isNumbers ? ` font-variant-numeric="tabular-nums" style="font-variant-numeric: tabular-nums"` : "";
       const textX = align === "left" ? rect.x : align === "right" ? rect.x + rect.width : rect.x + rect.width / 2;
       const textY = vAlign === "top" ? rect.y : vAlign === "bottom" ? rect.y + rect.height : rect.y + rect.height / 2;
-      const baseAttrs = `text-anchor="${textAnchorFor(align)}" dominant-baseline="${baselineFor(vAlign)}" font-family="${fontFamily}" font-size="${fontSize}" fill="${color}"${tabularAttr}`;
+      const baseAttrs = `text-anchor="${textAnchorFor(align)}" dominant-baseline="${baselineFor(vAlign)}" font-family="${fontFamily}" font-size="${fontSize}" fill="${color}"${tabularAttr}${textEffectAttrs(fx, item.id, clipPaths)}`;
       if (styledLines.length === 1) {
         pushEl(`<text x="${textX}" y="${textY}" ${baseAttrs}>${renderStyledLine(styledLines[0])}</text>`);
         return;
       }
       const tspans = styledLines.map((line, i) =>
-        `<tspan x="${textX}" ${i === 0 ? `y="${textY}"` : `dy="${fontSize * 1.2}"`}>${renderStyledLine(line)}</tspan>`
+        `<tspan x="${textX}" ${i === 0 ? `y="${textY}"` : `dy="${fontSize * (fx.lineHeight || 1.2)}"`}>${renderStyledLine(line)}</tspan>`
       ).join('');
       pushEl(`<text ${baseAttrs}>${tspans}</text>`);
       return;
@@ -653,7 +714,7 @@ export const renderCardSvg = (card: CardData, layoutMm: CardLayout, options: Ren
     const alignItems = align === "left" ? "flex-start" : align === "right" ? "flex-end" : "center";
     const html = styledLines.map(line => `<div>${renderStyledLineHtml(line)}</div>`).join('');
     const tabularStyle = isNumbers ? "font-variant-numeric:tabular-nums;" : "";
-    pushEl(`<foreignObject x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}"><div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:${alignItems};justify-content:${justifyContent};font-family:${fontFamily};font-size:${fontSize}px;color:${color};text-align:${align};${tabularStyle}overflow:hidden;word-wrap:break-word;overflow-wrap:break-word">${html}</div></foreignObject>`);
+    pushEl(`<foreignObject x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}"><div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:${alignItems};justify-content:${justifyContent};font-family:${fontFamily};font-size:${fontSize}px;color:${color};text-align:${align};${tabularStyle}${textEffectCss(fx)}overflow:hidden;word-wrap:break-word;overflow-wrap:break-word">${html}</div></foreignObject>`);
   });
 
   const renderedItems = itemElements.join("");
@@ -872,12 +933,13 @@ export const renderLayoutSvg = (layoutMm: CardLayout, options: LayoutSvgOptions 
     const align = item.align ?? "center";
     const vAlign = (item as any).verticalAlign ?? "middle";
     const color = escape(item.color ?? palette.ink);
+    const fx = textEffects((p) => resolve(item, p, emptyCard, layoutMm));
     const justifyContent = vAlign === "top" ? "flex-start" : vAlign === "bottom" ? "flex-end" : "center";
     const alignItems = align === "left" ? "flex-start" : align === "right" ? "flex-end" : "center";
     const styledLines = parseRichText(value);
     const html = styledLines.map(line => `<div>${renderStyledLineHtml(line)}</div>`).join('');
     const tabularStyle = isNumbers ? "font-variant-numeric:tabular-nums;" : "";
-    return wrapRot(`<foreignObject x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}"><div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:${alignItems};justify-content:${justifyContent};font-family:${fontFamily};font-size:${fontSize}px;color:${color};text-align:${align};${tabularStyle}overflow:hidden;word-wrap:break-word;overflow-wrap:break-word">${html}</div></foreignObject>`);
+    return wrapRot(`<foreignObject x="${rect.x}" y="${rect.y}" width="${rect.width}" height="${rect.height}"><div xmlns="http://www.w3.org/1999/xhtml" style="width:100%;height:100%;display:flex;flex-direction:column;align-items:${alignItems};justify-content:${justifyContent};font-family:${fontFamily};font-size:${fontSize}px;color:${color};text-align:${align};${tabularStyle}${textEffectCss(fx)}overflow:hidden;word-wrap:break-word;overflow-wrap:break-word">${html}</div></foreignObject>`);
   }).join("");
 
   // Section wireframes

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,8 +61,23 @@ type CardLayoutItemBase = {
   bindings?: Record<string, PropertyBinding>;
 };
 
+// Effects shared by text-like items (text, numbers)
+type TextEffectProps = {
+  // Text outline, painted under the fill (paint-order: stroke)
+  strokeColor?: string;
+  strokeWidth?: number;
+  // Drop shadow, rendered when shadowColor is set
+  shadowColor?: string;
+  shadowOffsetX?: number;
+  shadowOffsetY?: number;
+  shadowBlur?: number;
+  // Line height multiplier (browser default when unset) and letter spacing in px
+  lineHeight?: number;
+  letterSpacing?: number;
+};
+
 // Text item - displays text from a field
-export type CardLayoutTextItem = CardLayoutItemBase & {
+export type CardLayoutTextItem = CardLayoutItemBase & TextEffectProps & {
   type?: "text";  // Optional to support legacy items
   defaultValue?: string;
   fontSize: number;
@@ -106,7 +121,7 @@ export type CardLayoutCloneItem = CardLayoutItemBase & {
 
 // Numbers item - displays text from a field using tabular figures (CSS tabular-nums)
 // for properly aligned digits. Same shape as a text item.
-export type CardLayoutNumbersItem = CardLayoutItemBase & {
+export type CardLayoutNumbersItem = CardLayoutItemBase & TextEffectProps & {
   type: "numbers";
   defaultValue?: string;
   fontSize: number;

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -566,6 +566,9 @@ async function createFullTestGame(storage) {
           bindings: { defaultValue: { field: "name" } },
           fontSize: 32, align: "center", verticalAlign: "middle", font: "title", color: "#1a1a2e",
           rotation: 15, flipH: true, opacity: 60,
+          strokeWidth: 1.5, strokeColor: "#ffffff",
+          shadowColor: "#333333cc", shadowOffsetX: 2, shadowOffsetY: 3, shadowBlur: 4,
+          lineHeight: 1.4, letterSpacing: 2,
           anchor: { x: 0.5, y: 0.5 }, attach: { targetType: "section", targetId: "header", anchor: { x: 0.5, y: 0.5 } },
           widthMm: 100, heightMm: 100 },
       ]},
@@ -666,6 +669,12 @@ async function verifyFullTestGame(storage, gameId) {
   assert.equal(title.flipH, true, "flipH must survive the round trip");
   assert.equal(title.opacity, 60, "opacity must survive the round trip");
   assert.equal(title.font, "title"); assert.equal(title.color, "#1a1a2e");
+  assert.equal(title.strokeWidth, 1.5, "text strokeWidth must survive the round trip");
+  assert.equal(title.strokeColor, "#ffffff", "text strokeColor must survive the round trip");
+  assert.equal(title.shadowColor, "#333333cc", "shadowColor must survive the round trip");
+  assert.equal(title.shadowOffsetX, 2); assert.equal(title.shadowOffsetY, 3); assert.equal(title.shadowBlur, 4);
+  assert.equal(title.lineHeight, 1.4, "lineHeight must survive the round trip");
+  assert.equal(title.letterSpacing, 2, "letterSpacing must survive the round trip");
 
   // Frame item
   const border = items.find(i => i.id === "border-item");

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -497,3 +497,39 @@ test("normalizeLayout preserves item effect properties", () => {
   assert.equal(bad.maskUrl, undefined, "empty maskUrl is dropped");
   assert.equal(bad.opacity, 100, "empty opacity falls back to fully opaque");
 });
+
+test("normalizeLayout preserves text effect properties", () => {
+  const layout = normalizeLayout({
+    id: "l", name: "L", width: 63.5, height: 88.9, radius: 2, bleed: 1,
+    root: {
+      id: "root", name: "Root", layout: "stack", sizePct: 100, gap: 0, children: [],
+      items: [
+        { id: "fx", name: "Fx", type: "text", defaultValue: "Hello", fontSize: 20, align: "center",
+          strokeWidth: 1.5, strokeColor: "#ffffff",
+          shadowColor: "#333333cc", shadowOffsetX: 2, shadowOffsetY: -3, shadowBlur: 4,
+          lineHeight: 1.4, letterSpacing: 2,
+          anchor: { x: 0.5, y: 0.5 },
+          attach: { targetType: "section", targetId: "root", anchor: { x: 0.5, y: 0.5 } },
+          widthMm: 30, heightMm: 20 },
+        { id: "plain", name: "Plain", type: "numbers", defaultValue: "1", fontSize: 20, align: "center",
+          anchor: { x: 0.5, y: 0.5 },
+          attach: { targetType: "section", targetId: "root", anchor: { x: 0.5, y: 0.5 } },
+          widthMm: 30, heightMm: 20 },
+      ]
+    }
+  });
+  const [fx, plain] = layout.root.items;
+  assert.equal(fx.strokeWidth, 1.5);
+  assert.equal(fx.strokeColor, "#ffffff");
+  assert.equal(fx.shadowColor, "#333333cc");
+  assert.equal(fx.shadowOffsetX, 2);
+  assert.equal(fx.shadowOffsetY, -3);
+  assert.equal(fx.shadowBlur, 4);
+  assert.equal(fx.lineHeight, 1.4);
+  assert.equal(fx.letterSpacing, 2);
+  assert.equal(plain.strokeWidth, undefined);
+  assert.equal(plain.strokeColor, undefined);
+  assert.equal(plain.shadowColor, undefined);
+  assert.equal(plain.lineHeight, undefined);
+  assert.equal(plain.letterSpacing, undefined);
+});

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -969,3 +969,73 @@ test("neutral or invalid effects emit no wrapper attributes", () => {
   assert.ok(boundSvg.includes('opacity="0.4"'), "opacity should resolve through bindings");
   assert.ok(!boundSvg.includes("javascript:"), "non-whitelisted blend modes must be ignored");
 });
+
+const textFxLayout = (itemProps) => ({
+  version: 2,
+  id: "t",
+  name: "T",
+  width: 63.5,
+  height: 88.9,
+  radius: 2.5,
+  bleed: 1.5,
+  root: {
+    id: "root", name: "Root", layout: "stack", sizePct: 100, gap: 0, children: [],
+    items: [
+      { type: "text", id: "txt1", name: "Txt", defaultValue: "Hello\nWorld",
+        fontSize: 20, align: "center", verticalAlign: "middle", color: "#111111",
+        anchor: { x: 0.5, y: 0.5 },
+        attach: { targetType: "section", targetId: "root", anchor: { x: 0.5, y: 0.5 } },
+        widthMm: 40, heightMm: 20,
+        ...itemProps },
+    ],
+  },
+});
+
+test("text effects render in the foreignObject path (card + layout)", () => {
+  const card = { id: "t", name: "T", fields: {} };
+  const layout = textFxLayout({
+    strokeWidth: 1.5, strokeColor: "#ffffff",
+    shadowColor: "#333333", shadowOffsetX: 2, shadowOffsetY: 3, shadowBlur: 4,
+    lineHeight: 1.4, letterSpacing: 2,
+  });
+  for (const svg of [renderCardSvg(card, layout), renderLayoutSvg(layout)]) {
+    assert.ok(svg.includes("-webkit-text-stroke:1.5px #ffffff"), "Should stroke the text");
+    assert.ok(svg.includes("paint-order:stroke"), "Stroke should paint under the fill");
+    assert.ok(svg.includes("text-shadow:2px 3px 4px #333333"), "Should apply the drop shadow");
+    assert.ok(svg.includes("line-height:1.4"), "Should apply line height");
+    assert.ok(svg.includes("letter-spacing:2px"), "Should apply letter spacing");
+  }
+});
+
+test("text effects render in the svgTextOnly path", () => {
+  const card = { id: "t", name: "T", fields: {} };
+  const layout = textFxLayout({
+    strokeWidth: 1.5, strokeColor: "#ffffff",
+    shadowColor: "#333333", shadowOffsetX: 2, shadowOffsetY: 3, shadowBlur: 4,
+    lineHeight: 1.5, letterSpacing: 2,
+  });
+  const svg = renderCardSvg(card, layout, { svgTextOnly: true });
+  assert.ok(svg.includes('stroke="#ffffff" stroke-width="1.5"'), "Should stroke the text");
+  assert.ok(svg.includes('paint-order="stroke"'), "Stroke should paint under the fill");
+  assert.ok(svg.includes('letter-spacing="2"'), "Should apply letter spacing");
+  assert.ok(/<defs>[^]*<feDropShadow dx="2" dy="3" stdDeviation="2" flood-color="#333333"/.test(svg), "Shadow filter should be hoisted into <defs>");
+  assert.ok(svg.includes('filter="url(#shadow-txt1)"'), "Text should reference the shadow filter");
+  assert.ok(svg.includes(`dy="${20 * 1.5}"`), "Multi-line spacing should use the line height");
+});
+
+test("text without effects renders without effect styles", () => {
+  const card = { id: "t", name: "T", fields: {} };
+  const svg = renderCardSvg(card, textFxLayout({}));
+  assert.ok(!svg.includes("-webkit-text-stroke"), "No stroke by default");
+  assert.ok(!svg.includes("text-shadow"), "No shadow by default");
+  assert.ok(!svg.includes("line-height"), "No line-height override by default");
+  assert.ok(!svg.includes("letter-spacing"), "No letter spacing by default");
+});
+
+test("alpha mask uses luminance masking so opaque mask images have an effect", () => {
+  const card = { id: "t", name: "T", fields: {} };
+  const layout = effectsLayout({ maskUrl: "/api/games/g/images/mask.jpg" });
+  const svg = renderCardSvg(card, layout);
+  assert.ok(svg.includes('<mask id="mask-fx1"'), "Mask should be emitted");
+  assert.ok(!svg.includes("mask-type"), "Mask must not be alpha-typed (no effect for images without an alpha channel)");
+});


### PR DESCRIPTION
# Fix : masque alpha sans effet

Le masque était déclaré en `mask-type:alpha` : avec une image de galerie classique (JPEG ou PNG sans transparence), le canal alpha est plein partout → masque opaque → **aucun effet visible**. Le masque passe en mode **luminance** (défaut SVG, comme Photoshop) : blanc = visible, noir = masqué, et la transparence masque aussi. N'importe quelle image en niveaux de gris fonctionne maintenant directement.

# Effets de texte (items text et numbers)

| Propriété | Éditeur | Rendu foreignObject | Rendu svgTextOnly |
|---|---|---|---|
| Outline Width / Outline Color | nombre + couleur | `-webkit-text-stroke` + `paint-order:stroke` | `stroke`/`stroke-width` + `paint-order="stroke"` |
| Shadow Color / X / Y / Blur | couleur + nombres | `text-shadow` | filtre `feDropShadow` hoisté dans `<defs>` |
| Line Height | multiplicateur (0.5–3) | `line-height` | espacement des `tspan` multi-lignes |
| Letter Spacing | px (négatif autorisé) | `letter-spacing` | attribut `letter-spacing` |

- Le contour est peint **sous** le remplissage (paint-order), le rendu classique « texte blanc contour noir » marche donc proprement.
- L'ombre n'est active que si Shadow Color est définie (offsets par défaut 2px, blur 2px).
- Aucun style n'est émis pour les layouts non touchés — sortie SVG inchangée à l'octet près.
- Toutes les propriétés sont bindables, préservées par le normalizer et survivent au round-trip zip/backends.
- L'entrée serveur `cardSvg.ts` transmet désormais l'option `svgTextOnly` au core (elle était silencieusement ignorée).

# Tests et vérification

- Round-trip `backendCompat` étendu aux 8 nouveaux champs.
- Tests `normalize` (préservation + valeurs absentes) et `rendering` (deux chemins de rendu, filtre hoisté, absence de styles par défaut, masque luminance).
- Vérifié dans l'app (Playwright, mobile) : un masque moitié noir/moitié blanc appliqué via la galerie cache la moitié de l'item dans l'aperçu ; contour rouge + ombre bleue + letter-spacing visibles sur un item texte. 213/213 tests passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsxBwe1dZ4p4MyREyAxxef

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsxBwe1dZ4p4MyREyAxxef)_