### PR TITLE
Show the card back in the card list's big preview (flip + 3D)

### DIFF
--- a/src/components/FilterableList.tsx
+++ b/src/components/FilterableList.tsx
@@ -15,6 +15,8 @@ type FilterableListProps<T> = {
   getKey: (item: T) => string
   getName: (item: T) => string
   getPreviewSrc?: (item: T) => string
+  /** Rendered back of the item — enables the flip button (and the 3D back face) in the big preview. */
+  getBackSrc?: (item: T) => string | undefined
   getGroup?: (item: T) => string | undefined
   selectedKey?: string | null
   onSelect?: (key: string | null) => void
@@ -34,7 +36,7 @@ type FilterableListProps<T> = {
 
 const COL_WIDTH = 120
 
-export default function FilterableList<T>({ title, items, getKey, getName, getPreviewSrc, getGroup, selectedKey, onSelect, onRename, selectedKeys, onSelectedKeysChange, renderItem, toolbar, actions, drawer, subheader, empty, maxHeight = '60vh', grid: gridProp, viewMode: viewModeProp }: FilterableListProps<T>) {
+export default function FilterableList<T>({ title, items, getKey, getName, getPreviewSrc, getBackSrc, getGroup, selectedKey, onSelect, onRename, selectedKeys, onSelectedKeysChange, renderItem, toolbar, actions, drawer, subheader, empty, maxHeight = '60vh', grid: gridProp, viewMode: viewModeProp }: FilterableListProps<T>) {
   const multiSelect = !!(selectedKeys && onSelectedKeysChange)
   const [hoverThumb, setHoverThumb] = useState<{ src: string; x: number; y: number } | null>(null)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
@@ -263,7 +265,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
         )}
         {showBigPreview ? (<>
           <div className="overflow-hidden [&>*]:h-full [&>*]:border-0 [&>*]:rounded-none" style={{ height: 'calc(100% - 6.5rem)' }}>
-            <ZoomablePreview src={previewSrc} alt={getName(selectedItem!)} maxImgHeight="100%" />
+            <ZoomablePreview src={previewSrc} alt={getName(selectedItem!)} maxImgHeight="100%" backImage={selectedItem ? getBackSrc?.(selectedItem) : undefined} backFit="fill" />
           </div>
           <div className="relative h-[6.5rem] shrink-0 border-t bg-card">
             <div

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -1109,6 +1109,7 @@ export default function GameEditorPage() {
                 viewMode={{ key: `editor:${gameId}:viewMode`, default: 'compact' }}
                 grid={{ colsKey: `editor:${gameId}:galleryCols`, defaultCols: 2 }}
                 getPreviewSrc={(card: any) => cardThumbnails[card.id] ?? ''}
+                getBackSrc={(card: any) => card.id === selectedCardId ? (backPreview || undefined) : undefined}
                 selectedKey={selectedCardId}
                 onSelect={(key) => { if (key) selectCard(storage, key); else setSelectedCardId(null) }}
                 onRename={(cardId, name) => {


### PR DESCRIPTION
## Summary

Follow-up to #74. In the card list's **big-picture preview mode**, the 3D view showed the striped placeholder instead of the card's back, and the flip button was missing — that `ZoomablePreview` was built without a back image.

- `FilterableList` gains an optional `getBackSrc` prop, wired into the big preview's `ZoomablePreview` (`backImage` + `backFit="fill"`).
- The editor's card list feeds it the rendered back of the selected card — the same render the side preview and flip button already use, so it tracks card data and the back layout live.

## Testing

- All 213 tests pass; `tsc` and the production build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8

---
_Generated by [Claude Code](https://claude.ai/code/session_01EauZBxbkDzVYwPpVD7f6e8)_