### PR TITLE
Create new layouts with only the root section

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -1,5 +1,26 @@
 import type { CardLayout } from "./types";
 
+// Blank layout used when the user creates a new layout: just the root
+// section, no child sections and no items.
+export const emptyLayout = (): CardLayout => ({
+  version: 2,
+  id: "default",
+  name: "Default",
+  width: 63.5,
+  height: 88.9,
+  radius: 2.5,
+  bleed: 1.5,
+  root: {
+    id: "root",
+    name: "Root",
+    layout: "column",
+    sizePct: 100,
+    gap: 0,
+    children: [],
+    items: []
+  }
+});
+
 export const defaultLayout = (): CardLayout => ({
   version: 2,
   id: "default",

--- a/src/normalizeExport.js
+++ b/src/normalizeExport.js
@@ -1,2 +1,3 @@
-// JavaScript wrapper for normalize functions to be used in .js files
+// JavaScript wrapper for normalize/layout functions to be used in .js files
 export { normalizeCard, normalizeLayout } from "./normalize.js";
+export { emptyLayout } from "./layout.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import express from "express";
 import { renderCardSvg, renderLayoutSvg } from "./render/cardSvg.js";
-import { defaultLayout } from "./layout.js";
+import { defaultLayout, emptyLayout } from "./layout.js";
 import { normalizeCard, normalizeLayout } from "./normalize.js";
 import type { CardData, CardLayout, Collection } from "./types.js";
 
@@ -404,7 +404,7 @@ app.get("/api/games/:gameId/layouts", (req, res) => {
 app.post("/api/games/:gameId/layouts", (req, res) => {
   const gameId = req.params.gameId;
   const name = req.body?.name?.trim() || "New Layout";
-  const layout = defaultLayout();
+  const layout = emptyLayout();
   layout.id = uniqueId(slugify(name) || "layout", (id) => fs.existsSync(layoutFilePath(gameId, id)));
   layout.name = name;
   writeJson(layoutFilePath(gameId, layout.id), layout);

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -2,7 +2,7 @@ const DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.file";
 const DRIVE_API = "https://www.googleapis.com/drive/v3";
 const DRIVE_UPLOAD = "https://www.googleapis.com/upload/drive/v3";
 
-import { normalizeCard, normalizeLayout } from "../normalizeExport.js";
+import { normalizeCard, normalizeLayout, emptyLayout } from "../normalizeExport.js";
 import { getAsset, putAsset, deleteAsset } from "./assetCache.js";
 
 const loadGoogleScript = () =>
@@ -382,7 +382,7 @@ export const createGoogleDriveStorage = (options = {}) => {
 
   const createLayout = async (gameId, name) => {
     const tf = await layoutsFolder(gameId);
-    const tpl = defaultLayout();
+    const tpl = emptyLayout();
     // Random suffix like the indexedDB/S3 backends: a bare slug collides when
     // two layouts share a name, and Drive folders happily hold duplicates.
     const id = `${slugify(name) || "layout"}-${uid()}`;

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -4,7 +4,7 @@
  */
 
 import { getAsset, putAsset, deleteAsset, listAssets } from "./assetCache.js";
-import { normalizeCard, normalizeLayout } from "../normalizeExport.js";
+import { normalizeCard, normalizeLayout, emptyLayout } from "../normalizeExport.js";
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 
@@ -359,11 +359,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
       const db = await openDB();
       try {
         const layoutId = slugify(name) + "-" + uid();
-        const layout = normalizeLayout(
-          defaultLayout
-            ? { ...defaultLayout(), id: layoutId, name }
-            : { id: layoutId, name }
-        );
+        const layout = normalizeLayout({ ...emptyLayout(), id: layoutId, name });
         await idbPut(db, "layouts", [gameId, layoutId], layout);
         return layout;
       } finally {

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -12,7 +12,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import { getAsset, putAsset, deleteAsset } from "./assetCache.js";
-import { normalizeCard, normalizeLayout } from "../normalizeExport.js";
+import { normalizeCard, normalizeLayout, emptyLayout } from "../normalizeExport.js";
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 
@@ -341,11 +341,7 @@ export const createS3Storage = (options = {}) => {
 
     async createLayout(gameId, name) {
       const layoutId = slugify(name) + "-" + uid();
-      const layout = normalizeLayout(
-        defaultLayout
-          ? { ...defaultLayout(), id: layoutId, name }
-          : { id: layoutId, name }
-      );
+      const layout = normalizeLayout({ ...emptyLayout(), id: layoutId, name });
       await putJson(layoutKey(gameId, layoutId), layout);
       return layout;
     },

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it, before, after } from "node:test";
 import "fake-indexeddb/auto";
-import { defaultLayout } from "../src/layout.js";
+import { defaultLayout, emptyLayout } from "../src/layout.js";
 import { createLocalFileStorage } from "../src/storage/localFile.js";
 import { createIndexedDBStorage } from "../src/storage/indexedDB.js";
 import { createS3Storage } from "../src/storage/s3.js";
@@ -163,7 +163,7 @@ async function startServer() {
   });
   app.post("/api/games/:gid/layouts", async (c) => {
     const gid = c.req.param("gid"); const { name } = await c.req.json();
-    const tpl = { ...defaultLayout(), id: slug(name) || uid(), name };
+    const tpl = { ...emptyLayout(), id: slug(name) || uid(), name };
     writeJson(tplPath(gid, tpl.id), tpl); return c.json(tpl, 201);
   });
   app.get("/api/games/:gid/layouts/:tid", (c) => {


### PR DESCRIPTION
## Summary

When creating a new layout, it now starts empty: just the root section, with no child sections and no items. Previously every new layout was pre-filled with the full demo content (Header/Title, Body/Border/Artwork/Description).

## Changes

- **`src/layout.ts`**: added an `emptyLayout()` factory — same card dimensions as the default (63.5×88.9 mm, 2.5 mm radius, 1.5 mm bleed), but the root section is a bare `column` with empty `children`/`items`.
- **`src/server.ts`**: `POST /api/games/:gameId/layouts` (used by the localFile backend) now creates layouts from `emptyLayout()`.
- **`src/storage/indexedDB.js`, `src/storage/s3.js`, `src/storage/googleDrive.js`**: `createLayout` now uses `emptyLayout()` (imported via the existing `normalizeExport.js` wrapper for `.js` files).
- **`test/backendCompat.test.js`**: the mock localFile server's create-layout handler mirrors the real server's new behavior.

The demo layout (`defaultLayout()`) is unchanged and still used for the initial "Default" layout when creating a **new game**, and by the seed/legacy-build paths. `copyLayout` is unaffected.

## Testing

- `npm test`: 213/213 pass (includes backend-compat suites for localFile and IndexedDB, storage caching for all four backends).
- `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UzsEwF9UE76YaP7ZCYMkv

---
_Generated by [Claude Code](https://claude.ai/code/session_011UzsEwF9UE76YaP7ZCYMkv)_