### PR TITLE
Add custom tags and list sorting (name, tag, created, modified)

### DIFF
--- a/src/components/FilterableList.tsx
+++ b/src/components/FilterableList.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react'
-import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight, TextCursorInput, Check, X } from 'lucide-react'
+import { useState, useRef, useEffect, useCallback, useMemo, useId, type ReactNode } from 'react'
+import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight, TextCursorInput, Check, X, Tags, ArrowUpNarrowWide, ArrowDownWideNarrow } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import useFuzzyFilter from '@/hooks/useFuzzyFilter'
@@ -8,6 +8,24 @@ import ZoomablePreview from '@/components/ZoomablePreview'
 import CardThumbnail from '@/components/CardThumbnail'
 
 export type ViewMode = 'compact' | 'detailed' | 'gallery' | 'preview'
+
+export type SortBy = 'name' | 'tag' | 'created' | 'updated'
+type SortState = { by: SortBy; dir: 'asc' | 'desc' }
+// Names/tags read naturally A→Z; dates read naturally newest-first.
+const DEFAULT_DIR: Record<SortBy, 'asc' | 'desc'> = { name: 'asc', tag: 'asc', created: 'desc', updated: 'desc' }
+const naturalCompare = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare
+
+/** Small pill badges for an item's tags — drop into any renderItem. */
+export function TagBadges({ tags }: { tags?: string[] }) {
+  if (!tags?.length) return null
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {tags.map(t => (
+        <span key={t} className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] leading-none text-primary whitespace-nowrap">{t}</span>
+      ))}
+    </span>
+  )
+}
 
 type FilterableListProps<T> = {
   title: string
@@ -18,6 +36,15 @@ type FilterableListProps<T> = {
   /** Rendered back of the item — enables the flip button (and the 3D back face) in the big preview. */
   getBackSrc?: (item: T) => string | undefined
   getGroup?: (item: T) => string | undefined
+  // Custom tags: when provided, tags join the fuzzy filter, enable tag
+  // sorting, and (with onTagsChange) an editor for the selected item.
+  getTags?: (item: T) => string[] | undefined
+  onTagsChange?: (key: string, tags: string[]) => void | Promise<void>
+  // ISO timestamps enabling created/modified sorting
+  getCreatedAt?: (item: T) => string | undefined
+  getUpdatedAt?: (item: T) => string | undefined
+  // Enables the sort control; the key persists the choice in localStorage
+  sort?: { key: string }
   selectedKey?: string | null
   onSelect?: (key: string | null) => void
   onRename?: (key: string, newName: string) => void | Promise<void>
@@ -36,11 +63,68 @@ type FilterableListProps<T> = {
 
 const COL_WIDTH = 120
 
-export default function FilterableList<T>({ title, items, getKey, getName, getPreviewSrc, getBackSrc, getGroup, selectedKey, onSelect, onRename, selectedKeys, onSelectedKeysChange, renderItem, toolbar, actions, drawer, subheader, empty, maxHeight = '60vh', grid: gridProp, viewMode: viewModeProp }: FilterableListProps<T>) {
+export default function FilterableList<T>({ title, items, getKey, getName, getPreviewSrc, getBackSrc, getGroup, getTags, onTagsChange, getCreatedAt, getUpdatedAt, sort: sortProp, selectedKey, onSelect, onRename, selectedKeys, onSelectedKeysChange, renderItem, toolbar, actions, drawer, subheader, empty, maxHeight = '60vh', grid: gridProp, viewMode: viewModeProp }: FilterableListProps<T>) {
   const multiSelect = !!(selectedKeys && onSelectedKeysChange)
   const [hoverThumb, setHoverThumb] = useState<{ src: string; x: number; y: number } | null>(null)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
-  const [filtered, filterInput] = useFuzzyFilter(items, getName)
+  // Tags take part in fuzzy filtering, so typing a tag narrows the list.
+  const [matched, filterInput] = useFuzzyFilter(items, getTags ? (i: T) => `${getName(i)} ${(getTags(i) ?? []).join(' ')}` : getName)
+
+  // ── Sorting ─────────────────────────────────────────────────────
+  const sortOptions = useMemo(() => {
+    const opts: { value: SortBy; label: string }[] = [{ value: 'name', label: 'Name' }]
+    if (getTags) opts.push({ value: 'tag', label: 'Tag' })
+    if (getCreatedAt) opts.push({ value: 'created', label: 'Created' })
+    if (getUpdatedAt) opts.push({ value: 'updated', label: 'Modified' })
+    return opts
+  }, [!!getTags, !!getCreatedAt, !!getUpdatedAt])
+  const [sort, setSort] = useState<SortState>(() => {
+    if (sortProp) {
+      try {
+        const saved = JSON.parse(localStorage.getItem(sortProp.key) ?? 'null')
+        if (saved && ['name', 'tag', 'created', 'updated'].includes(saved.by) && ['asc', 'desc'].includes(saved.dir)) return saved
+      } catch {}
+    }
+    return { by: 'name', dir: 'asc' }
+  })
+  const setSortPersist = (s: SortState) => {
+    setSort(s)
+    if (sortProp) try { localStorage.setItem(sortProp.key, JSON.stringify(s)) } catch {}
+  }
+  // A persisted choice may reference accessors this list no longer provides.
+  const sortBy: SortBy = sortOptions.some(o => o.value === sort.by) ? sort.by : 'name'
+
+  const filtered = useMemo(() => {
+    const dirMul = sort.dir === 'desc' ? -1 : 1
+    const byName = (a: T, b: T) => naturalCompare(getName(a), getName(b))
+    const arr = [...matched]
+    if (sortBy === 'name') return arr.sort((a, b) => dirMul * byName(a, b))
+    const sortValue = (item: T): string | undefined => {
+      if (sortBy === 'tag') {
+        const tags = getTags?.(item) ?? []
+        return tags.length ? [...tags].sort(naturalCompare)[0] : undefined
+      }
+      return (sortBy === 'created' ? getCreatedAt?.(item) : getUpdatedAt?.(item)) || undefined
+    }
+    return arr.sort((a, b) => {
+      const va = sortValue(a), vb = sortValue(b)
+      // Items without a tag/date always sort last, whatever the direction.
+      if (va === undefined && vb === undefined) return byName(a, b)
+      if (va === undefined) return 1
+      if (vb === undefined) return -1
+      const cmp = sortBy === 'tag' ? naturalCompare(va, vb) : (va < vb ? -1 : va > vb ? 1 : 0)
+      return dirMul * cmp || byName(a, b)
+    })
+  }, [matched, sortBy, sort.dir, getName, getTags, getCreatedAt, getUpdatedAt])
+
+  // ── Tag editing (selected item) ─────────────────────────────────
+  const [editingTags, setEditingTags] = useState(false)
+  const [tagDraft, setTagDraft] = useState('')
+  const tagListId = useId()
+  const allTags = useMemo(
+    () => getTags ? [...new Set(items.flatMap(i => getTags(i) ?? []))].sort(naturalCompare) : [],
+    [items, getTags]
+  )
   const { collapsed, toggle } = useCollapsible()
   const containerRef = useRef<HTMLDivElement>(null)
   const itemRefs = useRef<Map<string, HTMLElement>>(new Map())
@@ -148,7 +232,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
   const selectedItem = selectedKey ? items.find(i => getKey(i) === selectedKey) : null
   const [renaming, setRenaming] = useState(false)
   const [renameDraft, setRenameDraft] = useState('')
-  useEffect(() => { setRenaming(false) }, [selectedKey])
+  useEffect(() => { setRenaming(false); setTagDraft('') }, [selectedKey])
   const startRename = () => {
     if (!selectedItem) return
     setRenameDraft(getName(selectedItem))
@@ -166,6 +250,37 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
       onClick={startRename}>
       <TextCursorInput className="h-4 w-4" />
     </button>
+  ) : null
+  const tagsButton = onTagsChange && getTags && selectedItem ? (
+    <button className={`rounded p-1 transition-colors ${editingTags ? 'text-primary' : 'text-muted-foreground hover:text-foreground'}`} title="Edit tags"
+      onClick={() => setEditingTags(v => !v)}>
+      <Tags className="h-4 w-4" />
+    </button>
+  ) : null
+  const selectedTags = selectedItem && getTags ? (getTags(selectedItem) ?? []) : []
+  const addTag = () => {
+    if (!selectedItem || !onTagsChange) return
+    const tag = tagDraft.trim()
+    setTagDraft('')
+    if (!tag || selectedTags.includes(tag)) return
+    onTagsChange(getKey(selectedItem), [...selectedTags, tag])
+  }
+  const sortControl = sortProp ? (
+    <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
+      <select
+        value={sortBy}
+        onChange={(e) => { const by = e.target.value as SortBy; setSortPersist({ by, dir: DEFAULT_DIR[by] }) }}
+        className="h-6 rounded border bg-background pl-1.5 pr-4 text-xs text-muted-foreground"
+        title="Sort by"
+      >
+        {sortOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+      <button className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors"
+        onClick={() => setSortPersist({ by: sortBy, dir: sort.dir === 'asc' ? 'desc' : 'asc' })}
+        title={sort.dir === 'asc' ? 'Ascending (click for descending)' : 'Descending (click for ascending)'}>
+        {sort.dir === 'asc' ? <ArrowUpNarrowWide className="h-3.5 w-3.5" /> : <ArrowDownWideNarrow className="h-3.5 w-3.5" />}
+      </button>
+    </div>
   ) : null
   // Explicit confirm/cancel: Enter or ✓ commits, Escape or ✗ cancels.
   const renameForm = (
@@ -243,6 +358,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
                   <span className="text-xs">{items.filter(i => selectedKeys!.has(getKey(i))).length}/{items.length}</span>
                 </label>
               )}
+              {sortControl}
               {subheader && <div className="flex items-center gap-1 ml-2">{subheader}</div>}
               {isGrid && <>
                 <button className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-30" disabled={cols <= 1}
@@ -257,10 +373,37 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
               </>}
 
               <div className="flex items-center gap-1 ml-auto">
+                {tagsButton}
                 {renameButton}
                 {actions}
               </div>
             </>)}
+          </div>
+        )}
+        {editingTags && !showBigPreview && selectedItem && onTagsChange && getTags && (
+          <div className="flex flex-wrap items-center gap-1 border-b px-2 py-1.5 shrink-0">
+            <Tags className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            {selectedTags.map(tag => (
+              <span key={tag} className="flex items-center gap-0.5 rounded-full bg-primary/10 pl-2 pr-0.5 py-0.5 text-xs text-primary">
+                {tag}
+                <button className="rounded-full p-0.5 hover:bg-primary/20 transition-colors" title="Remove tag"
+                  onClick={() => onTagsChange(getKey(selectedItem), selectedTags.filter(t => t !== tag))}>
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+            <form className="flex-1 min-w-[6rem]" onSubmit={(e) => { e.preventDefault(); addTag() }}>
+              <input
+                value={tagDraft}
+                onChange={(e) => setTagDraft(e.target.value)}
+                list={tagListId}
+                placeholder="Add tag..."
+                className="w-full h-6 rounded border bg-background px-2 text-xs outline-none focus:ring-1 focus:ring-primary"
+              />
+              <datalist id={tagListId}>
+                {allTags.filter(t => !selectedTags.includes(t)).map(t => <option key={t} value={t} />)}
+              </datalist>
+            </form>
           </div>
         )}
         {showBigPreview ? (<>

--- a/src/components/ImportPanel.tsx
+++ b/src/components/ImportPanel.tsx
@@ -146,7 +146,10 @@ export default function ImportPanel({
           }
         }
         if (!colId) continue
-        await storage.saveCard(gameId, colId, existing?.id ?? null, existing ? { ...existing, fields: card.fields } : card)
+        const stamp = new Date().toISOString()
+        await storage.saveCard(gameId, colId, existing?.id ?? null, existing
+          ? { ...existing, fields: card.fields, updatedAt: stamp }
+          : { ...card, createdAt: stamp, updatedAt: stamp })
       }
       for (const card of selectedMissing) {
         const colId = collectionId || (card as any)?.collectionId

--- a/src/gameZip.ts
+++ b/src/gameZip.ts
@@ -161,10 +161,16 @@ export const importGameZip = async (
     log(`Creating collection: ${col.id} (${col.name}) → layout: ${col.layoutId}`)
     const newCol = await storage.createCollection(newGameId, col.name, col.layoutId)
     const newColId = newCol.id
-    // Preserve extra collection fields (backLayoutId, etc.)
+    // Preserve extra collection fields (backLayoutId, tags, timestamps, etc.)
     // Layout ids are preserved verbatim on import, so backLayoutId needs no remap.
-    if (col.backLayoutId) {
-      await storage.updateCollection(newGameId, newColId, { backLayoutId: col.backLayoutId })
+    // Backends honor an explicit updatedAt in updates, so history survives.
+    const colExtras: Record<string, unknown> = {}
+    if (col.backLayoutId) colExtras.backLayoutId = col.backLayoutId
+    if (Array.isArray(col.tags) && col.tags.length) colExtras.tags = col.tags
+    if (col.createdAt) colExtras.createdAt = col.createdAt
+    if (col.updatedAt) colExtras.updatedAt = col.updatedAt
+    if (Object.keys(colExtras).length) {
+      await storage.updateCollection(newGameId, newColId, colExtras)
     }
 
     const colDir = f.name.replace('/collection.json', '')
@@ -173,6 +179,15 @@ export const importGameZip = async (
       const card = JSON.parse(rewriteAll(await cf.async('text')))
       await storage.saveCard(newGameId, newColId, card.id, card)
     }
+  }
+
+  // Preserve extra game fields (tags, creation date). Done last so the many
+  // imports above can't clobber them via backend touch/updatedAt stamping.
+  const gameExtras: Record<string, unknown> = {}
+  if (Array.isArray(gameMeta.tags) && gameMeta.tags.length) gameExtras.tags = gameMeta.tags
+  if (gameMeta.createdAt) gameExtras.createdAt = gameMeta.createdAt
+  if (Object.keys(gameExtras).length) {
+    await storage.updateGame(newGameId, gameExtras)
   }
 
   log('Done.')

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -270,8 +270,10 @@ export function useSaveLayout(gameId: string | undefined) {
   const storage = useStorageInstance()!
   const qc = useQueryClient()
   return useMutation<any, Error, { layoutId: string; layout: any }>({
+    // Every UI layout save flows through this hook, so this is where the
+    // last-modified stamp lives (zip import bypasses it and keeps history).
     mutationFn: ({ layoutId, layout }) =>
-      storage.saveLayout(gameId!, layoutId, layout),
+      storage.saveLayout(gameId!, layoutId, { ...layout, updatedAt: new Date().toISOString() }),
     onSuccess: (saved, vars) => {
       // Don't refetch — update both layout caches in place. Refetching would
       // cause a race that reverts edits (especially on slow backends like S3,
@@ -317,8 +319,10 @@ export function useSaveCard(gameId: string | undefined, collectionId: string | u
   const storage = useStorageInstance()!
   const qc = useQueryClient()
   return useMutation<any, Error, { cardId: string; card: any }>({
+    // UI card saves stamp the last-modified date here (zip import calls the
+    // backend directly and keeps the original timestamps).
     mutationFn: ({ cardId, card }) =>
-      storage.saveCard(gameId!, collectionId!, cardId, card),
+      storage.saveCard(gameId!, collectionId!, cardId, { ...card, updatedAt: new Date().toISOString() }),
     onSuccess: (saved) => {
       // In-place update (or append for a new card) instead of a refetch — see
       // useSaveLayout for why refetching misbehaves on slow backends.
@@ -376,7 +380,9 @@ export function useTransferCard(gameId: string | undefined) {
   return useMutation<any, Error, { sourceCollectionId: string; targetCollectionId: string; card: any; mode: 'copy' | 'move' }>({
     mutationFn: async ({ sourceCollectionId, targetCollectionId, card, mode }) => {
       const targetId = mode === 'move' ? card.id : null
-      const saved = await storage.saveCard(gameId!, targetCollectionId, targetId, { ...card, id: targetId ?? undefined })
+      // A copy is a new card and gets fresh timestamps; a move keeps them.
+      const stamp = mode === 'copy' ? { createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() } : {}
+      const saved = await storage.saveCard(gameId!, targetCollectionId, targetId, { ...card, id: targetId ?? undefined, ...stamp })
       if (mode === 'move') await storage.deleteCard(gameId!, sourceCollectionId, card.id)
       return saved
     },

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -68,6 +68,22 @@ const normalizeBindings = (obj: Record<string, unknown>): Record<string, Propert
     return Object.keys(result).length > 0 ? result : undefined;
 };
 
+/** Normalize a user-defined tag list: strings only, trimmed, deduped, empty → undefined. */
+const normalizeTags = (value: unknown): string[] | undefined => {
+    if (!Array.isArray(value)) return undefined;
+    const tags: string[] = [];
+    for (const raw of value) {
+        if (typeof raw !== "string") continue;
+        const tag = raw.trim();
+        if (tag && !tags.includes(tag)) tags.push(tag);
+    }
+    return tags.length > 0 ? tags : undefined;
+};
+
+/** Preserve an ISO timestamp string, dropping empty/non-string values. */
+const normalizeTimestamp = (value: unknown): string | undefined =>
+    typeof value === "string" && value !== "" ? value : undefined;
+
 // Counter so that several id-less nodes normalized in the same millisecond
 // still get distinct fallback ids (Date.now() alone collides within one pass).
 let fallbackIdCounter = 0;
@@ -287,6 +303,9 @@ export const normalizeLayout = (layout: unknown): CardLayout => {
         bleed,
         bindingMeta: Object.keys(bindingMeta).length > 0 ? bindingMeta : undefined,
         root,
+        tags: normalizeTags(obj.tags),
+        createdAt: normalizeTimestamp(obj.createdAt),
+        updatedAt: normalizeTimestamp(obj.updatedAt),
     };
 };
 /**
@@ -303,6 +322,9 @@ export const normalizeCard = (card: unknown): CardData => {
     return {
         id,
         name,
-        fields: Object.fromEntries(Object.entries(fields).map(([key, value]) => [key, safeString(value, "")]))
+        fields: Object.fromEntries(Object.entries(fields).map(([key, value]) => [key, safeString(value, "")])),
+        tags: normalizeTags(obj.tags),
+        createdAt: normalizeTimestamp(obj.createdAt),
+        updatedAt: normalizeTimestamp(obj.updatedAt),
     };
 };

--- a/src/pages/CollectionsPage.tsx
+++ b/src/pages/CollectionsPage.tsx
@@ -14,7 +14,7 @@ import ImportPanel from '@/components/ImportPanel'
 import ZipMergePanel from '@/components/ZipMergePanel'
 import CardThumbnail from '@/components/CardThumbnail'
 import LoadingImg from '@/components/LoadingImg'
-import FilterableList from '@/components/FilterableList'
+import FilterableList, { TagBadges } from '@/components/FilterableList'
 import PageLayout from '@/components/PageLayout'
 import FontManager, { FontPreview, FontPreviewEditor, defaultPreviewText } from '@/components/FontManager'
 import useStorage from '../hooks/useStorage'
@@ -474,6 +474,15 @@ export default function CollectionsPage() {
               items={collections}
               getKey={(col: any) => col.id}
               getName={(col: any) => col.name}
+              getTags={(col: any) => col.tags}
+              getCreatedAt={(col: any) => col.createdAt}
+              getUpdatedAt={(col: any) => col.updatedAt}
+              sort={{ key: `game:${gameId}:collectionsSort` }}
+              onTagsChange={async (collectionId, tags) => {
+                try {
+                  await updateCollectionMut.mutateAsync({ collectionId, updates: { tags } })
+                } catch { setStatus('Error updating tags.') }
+              }}
               selectedKey={expandedCollection}
               onSelect={(key) => {
                 setExpandedCollection(key)
@@ -507,8 +516,9 @@ export default function CollectionsPage() {
                       const newCol = await storage.createCollection(gameId, `${col.name} (copy)`, col.layoutId)
                       const cards = await storage.listCards(gameId, col.id)
                       const copies: any[] = []
+                      const cloneStamp = new Date().toISOString()
                       for (const card of cards) {
-                        copies.push(await storage.saveCard(gameId, newCol.id, null, { ...card, id: undefined, name: card.name }))
+                        copies.push(await storage.saveCard(gameId, newCol.id, null, { ...card, id: undefined, name: card.name, createdAt: cloneStamp, updatedAt: cloneStamp }))
                       }
                       // Seed the caches directly — a full refetch is slow on S3
                       // and can serve pre-clone listings.
@@ -572,7 +582,10 @@ export default function CollectionsPage() {
               ) : undefined}
               renderItem={(col: any, _vm, selected) => (
                     <ListItem selected={selected}>
-                      <span className="font-medium truncate">{col.name}</span>
+                      <span className="flex items-center gap-2 min-w-0">
+                        <span className="font-medium truncate">{col.name}</span>
+                        <TagBadges tags={col.tags} />
+                      </span>
                     </ListItem>
                   )}
                 />
@@ -583,6 +596,17 @@ export default function CollectionsPage() {
                   items={collectionCards}
                   getKey={(card: any) => card.id}
                   getName={(card: any) => card.name}
+                  getTags={(card: any) => card.tags}
+                  getCreatedAt={(card: any) => card.createdAt}
+                  getUpdatedAt={(card: any) => card.updatedAt}
+                  sort={{ key: `game:${gameId}:collCardSort` }}
+                  onTagsChange={async (cardId, tags) => {
+                    const card = collectionCards.find((c: any) => c.id === cardId)
+                    if (!card) return
+                    try {
+                      await saveCardMut.mutateAsync({ cardId, card: { ...card, tags } })
+                    } catch { setStatus('Error updating tags.') }
+                  }}
                   empty={cardsLoading
                     ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                     : <p className="text-sm text-muted-foreground text-center py-4">No cards in this collection.</p>}
@@ -635,7 +659,7 @@ export default function CollectionsPage() {
                       e.preventDefault()
                       if (!newCollCardName.trim() || !expandedCollection) return
                       const name = newCollCardName.trim()
-                      const newCard = { id: crypto.randomUUID(), name, fields: {} }
+                      const newCard = { id: crypto.randomUUID(), name, fields: {}, createdAt: new Date().toISOString() }
                       try {
                         await saveCardMut.mutateAsync({ cardId: newCard.id, card: newCard })
                         setSelectedCardId(newCard.id)
@@ -663,11 +687,12 @@ export default function CollectionsPage() {
                     />
                   ) : (
                     <ListItem selected={selected}>
-                      <div className={vm === 'detailed' ? 'flex items-center gap-3' : ''}>
+                      <div className={vm === 'detailed' ? 'flex items-center gap-3' : 'flex items-center gap-2'}>
                         {vm === 'detailed' && cardPreviews[card.id] && (
                           <img src={cardPreviews[card.id]} alt="" className="h-16 w-auto rounded border object-contain shrink-0 bg-white" />
                         )}
                         <span className="text-sm font-medium">{card.name}</span>
+                        <TagBadges tags={card.tags} />
                       </div>
                     </ListItem>
                   )}
@@ -688,6 +713,17 @@ export default function CollectionsPage() {
                 items={layouts}
                 getKey={(tpl: any) => tpl.id}
                 getName={(tpl: any) => tpl.name}
+                getTags={(tpl: any) => tpl.tags}
+                getCreatedAt={(tpl: any) => tpl.createdAt}
+                getUpdatedAt={(tpl: any) => tpl.updatedAt}
+                sort={{ key: `game:${gameId}:layoutsSort` }}
+                onTagsChange={async (layoutId, tags) => {
+                  const tpl = layouts.find((t: any) => t.id === layoutId)
+                  if (!tpl) return
+                  try {
+                    await saveLayoutMut.mutateAsync({ layoutId, layout: { ...tpl, tags } })
+                  } catch { setStatus('Error updating tags.') }
+                }}
                 selectedKey={selectedLayoutId}
                 onSelect={(key) => {
                   setSelectedLayoutId(key)
@@ -756,8 +792,11 @@ export default function CollectionsPage() {
                 ) : undefined}
                 renderItem={(tpl: any, _vm, selected) => (
                   <ListItem selected={selected}>
-                    <span className="font-medium">{tpl.name}</span>
-                    <span className="ml-2 text-xs text-muted-foreground">{tpl.width}×{tpl.height}</span>
+                    <span className="flex items-center gap-2 min-w-0">
+                      <span className="font-medium truncate">{tpl.name}</span>
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">{tpl.width}×{tpl.height}</span>
+                      <TagBadges tags={tpl.tags} />
+                    </span>
                   </ListItem>
                 )}
               />
@@ -842,6 +881,7 @@ export default function CollectionsPage() {
                 items={showUnusedImagesOnly ? unusedImages : gameImages}
                 getKey={img => img.file}
                 getName={img => img.name}
+                sort={{ key: `game:${gameId}:imagesSort` }}
                 viewMode={{ key: `game:${gameId}:imageViewMode`, default: 'gallery' }}
                 grid={{ colsKey: 'imageCols' }}
                 getPreviewSrc={img => img.url}

--- a/src/pages/GameEditorPage.tsx
+++ b/src/pages/GameEditorPage.tsx
@@ -28,7 +28,7 @@ import { FloatingInput, FloatingSelect } from '@/components/ui/floating-field'
 import ZoomablePreview from '@/components/ZoomablePreview'
 import ConfirmButton from '@/components/ConfirmButton'
 import LoadingImg from '@/components/LoadingImg'
-import FilterableList from '@/components/FilterableList'
+import FilterableList, { TagBadges } from '@/components/FilterableList'
 import ListItem from '@/components/ListItem'
 import CardThumbnail from '@/components/CardThumbnail'
 import PageLayout from '@/components/PageLayout'
@@ -273,8 +273,9 @@ function DataSheet({ cards, gameId, collectionId, layout, backLayout, gameImages
   }, [cards, fieldItemTypes])
 
   const saveCard = async (cardId: string, updated: any) => {
-    onCardsChange(prev => prev.map(c => c.id === cardId ? updated : c))
-    try { await onSaveCard(updated) }
+    const stamped = { ...updated, updatedAt: new Date().toISOString() }
+    onCardsChange(prev => prev.map(c => c.id === cardId ? stamped : c))
+    try { await onSaveCard(stamped) }
     catch { onStatusChange('Error saving card.') }
   }
 
@@ -821,7 +822,8 @@ export default function GameEditorPage() {
   const handleCreateCard = async (name?: string) => {
     if (!gameId || !collectionId) return
     const cardName = name?.trim() || `New Card ${cards.length + 1}`
-    const newCard = { id: crypto.randomUUID(), name: cardName, fields: {} }
+    const stamp = new Date().toISOString()
+    const newCard = { id: crypto.randomUUID(), name: cardName, fields: {}, createdAt: stamp, updatedAt: stamp }
     setCards(prev => [...prev, newCard as any])
     setSelectedCardId(newCard.id)
     setSavedCardJson(JSON.stringify(newCard))
@@ -878,7 +880,9 @@ export default function GameEditorPage() {
 
   const updateCard = (fn: (card: any) => any) => {
     if (!selectedCardId) return
-    setCards(prev => prev.map(c => c.id === selectedCardId ? fn(c) : c))
+    // Every edit refreshes the last-modified stamp; the auto-save effect
+    // persists the card (including the stamp) shortly after.
+    setCards(prev => prev.map(c => c.id === selectedCardId ? { ...fn(c), updatedAt: new Date().toISOString() } : c))
   }
 
   // Layout handlers – optimistic update + immediate persist.
@@ -1105,6 +1109,14 @@ export default function GameEditorPage() {
                 items={cards}
                 getKey={(card: any) => card.id}
                 getName={(card: any) => card.name ?? ''}
+                getTags={(card: any) => card.tags}
+                getCreatedAt={(card: any) => card.createdAt}
+                getUpdatedAt={(card: any) => card.updatedAt}
+                sort={{ key: `editor:${gameId}:cardSort` }}
+                onTagsChange={(cardId, tags) => {
+                  // Local update only — the selected-card auto-save effect persists it.
+                  setCards(prev => prev.map(c => c.id === cardId ? { ...c, tags, updatedAt: new Date().toISOString() } : c))
+                }}
                 maxHeight="60vh"
                 viewMode={{ key: `editor:${gameId}:viewMode`, default: 'compact' }}
                 grid={{ colsKey: `editor:${gameId}:galleryCols`, defaultCols: 2 }}
@@ -1114,7 +1126,7 @@ export default function GameEditorPage() {
                 onSelect={(key) => { if (key) selectCard(storage, key); else setSelectedCardId(null) }}
                 onRename={(cardId, name) => {
                   // Local update only — the selected-card auto-save effect persists it.
-                  setCards(prev => prev.map(c => c.id === cardId ? { ...c, name } : c))
+                  setCards(prev => prev.map(c => c.id === cardId ? { ...c, name, updatedAt: new Date().toISOString() } : c))
                 }}
                 empty={cardsLoading
                   ? <div className="flex items-center justify-center py-8"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
@@ -1169,11 +1181,12 @@ export default function GameEditorPage() {
                   />
                 ) : (
                   <ListItem selected={selected}>
-                    <div className={vm === 'detailed' ? 'flex items-center gap-3' : ''}>
+                    <div className={vm === 'detailed' ? 'flex items-center gap-3' : 'flex items-center gap-2'}>
                       {vm === 'detailed' && cardThumbnails[card.id] && (
                         <LoadingImg src={cardThumbnails[card.id]} alt="" className="h-16 w-auto rounded border object-contain shrink-0 bg-white" />
                       )}
                       <span className="text-sm font-medium">{card.name}</span>
+                      <TagBadges tags={card.tags} />
                     </div>
                   </ListItem>
                 )}

--- a/src/pages/GamesPage.tsx
+++ b/src/pages/GamesPage.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import CollapsibleHeader, { useCollapsible } from '@/components/ui/CollapsibleHeader'
 import ConfirmButton from '@/components/ConfirmButton'
 import ListItem from '@/components/ListItem'
-import FilterableList from '@/components/FilterableList'
+import FilterableList, { TagBadges } from '@/components/FilterableList'
 import PageLayout from '@/components/PageLayout'
 import useStorage from '../hooks/useStorage'
 import { useGames, useCreateGame, useDeleteGame, queryKeys } from '../hooks/useGameData'
@@ -47,6 +47,13 @@ export default function GamesPage() {
       setExpandedGame(games[0].id)
     }
   }, [games])
+
+  // In-place cache update — a refetch on slow backends (S3) keeps showing
+  // the old tags for seconds, as if the edit did nothing.
+  const qcSetGameTags = (gameId: string, updated: any) => {
+    queryClient.setQueryData<any[]>(queryKeys.games(), (old) =>
+      old ? old.map((g: any) => g.id === gameId ? { ...g, ...updated } : g) : old)
+  }
 
   const handleCreateGame = async () => {
     if (!storage) {
@@ -244,8 +251,21 @@ export default function GamesPage() {
             items={games}
             getKey={(game: any) => game.id}
             getName={(game: any) => game.name}
+            getTags={(game: any) => game.tags}
+            getCreatedAt={(game: any) => game.createdAt}
+            getUpdatedAt={(game: any) => game.updatedAt}
+            sort={{ key: 'games:sort' }}
             selectedKey={expandedGame}
             onSelect={setExpandedGame}
+            onTagsChange={async (gameId, tags) => {
+              if (!storage) return
+              try {
+                const updated = await storage.updateGame(gameId, { tags })
+                qcSetGameTags(gameId, updated ?? { tags })
+              } catch (err) {
+                setError('Error updating tags', err)
+              }
+            }}
             onRename={async (gameId, name) => {
               if (!storage) return
               try {
@@ -302,7 +322,10 @@ export default function GamesPage() {
             })() : undefined}
             renderItem={(game: any, _vm, selected) => (
               <ListItem selected={selected}>
-                <span className="font-medium">{game.name}</span>
+                <span className="flex items-center gap-2 min-w-0">
+                  <span className="font-medium truncate">{game.name}</span>
+                  <TagBadges tags={game.tags} />
+                </span>
               </ListItem>
             )}
           />

--- a/src/server.ts
+++ b/src/server.ts
@@ -462,7 +462,8 @@ app.post("/api/games/:gameId/collections", (req, res) => {
   if (!layoutId) return res.status(400).json({ error: "layoutId required" });
   if (!loadLayout(gameId, layoutId)) return res.status(404).json({ error: "Layout not found" });
   const id = uniqueId(slugify(name) || "collection", (id) => fs.existsSync(collectionDir(gameId, id)));
-  const collection: Collection = { id, name, layoutId };
+  const now = new Date().toISOString();
+  const collection: Collection = { id, name, layoutId, createdAt: now, updatedAt: now };
   fs.mkdirSync(collectionCardsDir(gameId, id), { recursive: true });
   writeJson(collectionPath(gameId, id), collection);
   touchGame(gameId);
@@ -480,7 +481,8 @@ app.put("/api/games/:gameId/collections/:collectionId", (req, res) => {
   const col = readJson<Collection | null>(collectionPath(gameId, collectionId), null);
   if (!col) return res.status(404).json({ error: "Not found" });
   if (req.body.layoutId && !loadLayout(gameId, req.body.layoutId)) return res.status(404).json({ error: "Layout not found" });
-  const updated = { ...col, ...req.body, id: collectionId };
+  // An explicit updatedAt in the payload wins — zip import uses it to preserve history.
+  const updated = { ...col, ...req.body, id: collectionId, updatedAt: req.body.updatedAt ?? new Date().toISOString() };
   writeJson(collectionPath(gameId, collectionId), updated);
   touchGame(gameId);
   res.json(updated);
@@ -553,7 +555,8 @@ app.post("/api/games/:gameId/collections/:collectionId/cards/:cardId/copy", (req
   const existing = listCollectionCards(gameId, collectionId);
   const newName = `New Card ${existing.length + 1}`;
   const newId = uniqueId(slugify(newName) || `card-${Date.now()}`, (id) => fs.existsSync(collectionCardPath(gameId, collectionId, id)));
-  const copy = { ...card, id: newId, name: newName };
+  const copyStamp = new Date().toISOString();
+  const copy = { ...card, id: newId, name: newName, createdAt: copyStamp, updatedAt: copyStamp };
   writeJson(collectionCardPath(gameId, collectionId, newId), copy);
   touchGame(gameId);
   res.status(201).json(copy);

--- a/src/storage/backend.ts
+++ b/src/storage/backend.ts
@@ -5,6 +5,8 @@ export type GameMeta = {
   name: string;
   createdAt?: string;
   updatedAt?: string;
+  // User-defined labels for filtering/sorting in lists
+  tags?: string[];
   [key: string]: unknown;
 };
 

--- a/src/storage/googleDrive.js
+++ b/src/storage/googleDrive.js
@@ -456,7 +456,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     // Random suffix like the indexedDB/S3 backends — a bare slug would reuse
     // the existing folder for a same-named collection and merge their cards.
     const id = `${slugify(name) || "col"}-${uid()}`;
-    const col = { id, name, layoutId };
+    const col = { id, name, layoutId, createdAt: now(), updatedAt: now() };
     const cf = await collectionFolder(gameId, id);
     await mkFile("collection.json", col, cf, { type: "collection", gameId, collectionId: id });
     await ensureFolder(cf, "cards", `cards:${gameId}:${id}`);
@@ -468,7 +468,8 @@ export const createGoogleDriveStorage = (options = {}) => {
     const cf = await collectionFolder(gameId, collectionId);
     const fid = await findOrCreate(cf, "collection.json", key, { id: collectionId, name: collectionId, layoutId: "default" });
     const col = await readFile(fid);
-    const next = { ...col, ...updates, id: collectionId };
+    // An explicit updatedAt in the updates wins — zip import uses it to preserve history.
+    const next = { ...col, ...updates, id: collectionId, updatedAt: updates.updatedAt ?? now() };
     await writeFile(fid, next);
     return next;
   };
@@ -536,7 +537,7 @@ export const createGoogleDriveStorage = (options = {}) => {
     const cards = await listCards(gameId, collectionId);
     const name = `New Card ${cards.length + 1}`;
     const id = slugify(name) || `card-${Date.now()}`;
-    return await saveCard(gameId, collectionId, id, { ...card, id, name });
+    return await saveCard(gameId, collectionId, id, { ...card, id, name, createdAt: now(), updatedAt: now() });
   };
 
   // --- Fonts (per-game) ---

--- a/src/storage/indexedDB.js
+++ b/src/storage/indexedDB.js
@@ -429,6 +429,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
           name,
           layoutId,
           createdAt: now(),
+          updatedAt: now(),
         };
         await idbPut(db, "collections", [gameId, collectionId], collection);
         return collection;
@@ -442,7 +443,8 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
       try {
         const col = await idbGet(db, "collections", [gameId, collectionId]);
         if (!col) throw new Error(`Collection not found: ${collectionId}`);
-        const updated = { ...col, ...updates, id: collectionId, updatedAt: now() };
+        // An explicit updatedAt in the updates wins — zip import uses it to preserve history.
+        const updated = { ...col, ...updates, id: collectionId, updatedAt: updates.updatedAt ?? now() };
         await idbPut(db, "collections", [gameId, collectionId], updated);
         return updated;
       } finally {
@@ -502,7 +504,7 @@ export const createIndexedDBStorage = ({ defaultLayout } = {}) => {
         const source = await idbGet(db, "cards", [gameId, collectionId, cardId]);
         if (!source) throw new Error(`Card not found: ${cardId}`);
         const newId = uid();
-        const copy = normalizeCard({ ...source, id: newId, name: `${source.name} (copy)` });
+        const copy = normalizeCard({ ...source, id: newId, name: `${source.name} (copy)`, createdAt: now(), updatedAt: now() });
         await idbPut(db, "cards", [gameId, collectionId, newId], copy);
         return copy;
       } finally {

--- a/src/storage/s3.js
+++ b/src/storage/s3.js
@@ -403,6 +403,7 @@ export const createS3Storage = (options = {}) => {
         name,
         layoutId,
         createdAt: now(),
+        updatedAt: now(),
       };
       await putJson(collectionKey(gameId, collectionId), collection);
       return collection;
@@ -410,7 +411,8 @@ export const createS3Storage = (options = {}) => {
 
     async updateCollection(gameId, collectionId, updates) {
       const col = await getJson(collectionKey(gameId, collectionId));
-      const updated = { ...col, ...updates, id: collectionId, updatedAt: now() };
+      // An explicit updatedAt in the updates wins — zip import uses it to preserve history.
+      const updated = { ...col, ...updates, id: collectionId, updatedAt: updates.updatedAt ?? now() };
       await putJson(collectionKey(gameId, collectionId), updated);
       return updated;
     },
@@ -458,6 +460,8 @@ export const createS3Storage = (options = {}) => {
         ...source,
         id: newId,
         name: `${source.name} (copy)`,
+        createdAt: now(),
+        updatedAt: now(),
       });
       await putJson(cardKey(gameId, collectionId, newId), copy);
       return copy;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,11 @@ export type CardData = {
   id: string;
   name: string;
   fields: Record<string, string>;
+  // User-defined labels for filtering/sorting in lists
+  tags?: string[];
+  // ISO timestamps, stamped by the app on create/save (absent on legacy data)
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 export type AnchorPoint = {
@@ -172,6 +177,11 @@ export type CardLayout = {
   bleed: number;
   bindingMeta?: Record<string, { default?: string; values?: string[] }>;
   root: CardLayoutSection;
+  // User-defined labels for filtering/sorting in lists
+  tags?: string[];
+  // ISO timestamps (absent on legacy data)
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 export type Collection = {
@@ -180,4 +190,9 @@ export type Collection = {
   layoutId: string;
   // Card back layout, rendered like the front. No back when unset.
   backLayoutId?: string;
+  // User-defined labels for filtering/sorting in lists
+  tags?: string[];
+  // ISO timestamps, stamped by the backends (absent on legacy data)
+  createdAt?: string;
+  updatedAt?: string;
 };

--- a/test/backendCompat.test.js
+++ b/test/backendCompat.test.js
@@ -537,6 +537,10 @@ async function createFullTestGame(storage) {
   const game = await storage.createGame("Transfer Test");
   const gameId = game.id;
 
+  // Game tags + creation date must survive export/import (restored at the
+  // end of importGameZip via updateGame).
+  await storage.updateGame(gameId, { tags: ["fantasy", "wip"], createdAt: "2024-01-01T00:00:00.000Z" });
+
   // Upload fonts with realistic names (spaces!)
   await storage.addGoogleFont(gameId, "Playwrite IE", "title");
   await storage.addGoogleFont(gameId, "Space Grotesk", "body");
@@ -549,6 +553,9 @@ async function createFullTestGame(storage) {
   const layouts = await storage.listLayouts(gameId);
   const tpl = layouts[0];
   tpl.name = "Full Layout";
+  tpl.tags = ["fancy", "v2"];
+  tpl.createdAt = "2024-02-01T00:00:00.000Z";
+  tpl.updatedAt = "2024-02-02T00:00:00.000Z";
   tpl.width = 70;
   tpl.height = 120;
   tpl.radius = 3;
@@ -615,14 +622,23 @@ async function createFullTestGame(storage) {
   };
   await storage.saveLayout(gameId, tpl.id, tpl);
 
-  // Set a layout back on the default collection
+  // Set a layout back, tags and explicit timestamps on the default collection.
+  // Backends honor an explicit updatedAt so history survives zip transfers.
   const cols = await storage.listCollections(gameId);
-  await storage.updateCollection(gameId, cols[0].id, { backLayoutId: tpl.id });
+  await storage.updateCollection(gameId, cols[0].id, {
+    backLayoutId: tpl.id,
+    tags: ["core", "print-ready"],
+    createdAt: "2024-03-01T00:00:00.000Z",
+    updatedAt: "2024-03-02T00:00:00.000Z",
+  });
 
   // Cards
   await storage.saveCard(gameId, cols[0].id, "card-1", {
     id: "card-1", name: "Warrior",
     fields: { cost: "5", description: "<b>Brave</b> hero", image: imageUrl, faction: "⚔️" },
+    tags: ["hero", "melee"],
+    createdAt: "2024-04-01T00:00:00.000Z",
+    updatedAt: "2024-04-02T00:00:00.000Z",
   });
   await storage.saveCard(gameId, cols[0].id, "card-2", {
     id: "card-2", name: "Mage",
@@ -643,11 +659,16 @@ async function createFullTestGame(storage) {
 async function verifyFullTestGame(storage, gameId) {
   const game = await storage.getGame(gameId);
   assert.equal(game.name, "Transfer Test");
+  assert.deepEqual(game.tags, ["fantasy", "wip"], "game tags must survive the round trip");
+  assert.equal(game.createdAt, "2024-01-01T00:00:00.000Z", "game createdAt must survive the round trip");
 
   const layouts = await storage.listLayouts(gameId);
   assert.equal(layouts.length, 1);
   const tpl = layouts[0];
   assert.equal(tpl.name, "Full Layout");
+  assert.deepEqual(tpl.tags, ["fancy", "v2"], "layout tags must survive the round trip");
+  assert.equal(tpl.createdAt, "2024-02-01T00:00:00.000Z", "layout createdAt must survive the round trip");
+  assert.equal(tpl.updatedAt, "2024-02-02T00:00:00.000Z", "layout updatedAt must survive the round trip");
   assert.equal(tpl.width, 70);
   assert.equal(tpl.height, 120);
   assert.equal(tpl.radius, 3);
@@ -740,6 +761,9 @@ async function verifyFullTestGame(storage, gameId) {
   // Collection metadata
   const defCol = cols.find(c => c.name === "Default");
   assert.equal(defCol.backLayoutId, tpl.id, "backLayoutId must survive the round trip");
+  assert.deepEqual(defCol.tags, ["core", "print-ready"], "collection tags must survive the round trip");
+  assert.equal(defCol.createdAt, "2024-03-01T00:00:00.000Z", "collection createdAt must survive the round trip");
+  assert.equal(defCol.updatedAt, "2024-03-02T00:00:00.000Z", "collection updatedAt must survive the round trip");
 
   // Cards
   const defCards = await storage.listCards(gameId, defCol.id);
@@ -748,6 +772,9 @@ async function verifyFullTestGame(storage, gameId) {
   assert.ok(warrior); assert.equal(warrior.fields.faction, "⚔️");
   assert.equal(warrior.fields.cost, "5");
   assert.ok(warrior.fields.image.includes(`/api/games/${gameId}/images/`));
+  assert.deepEqual(warrior.tags, ["hero", "melee"], "card tags must survive the round trip");
+  assert.equal(warrior.createdAt, "2024-04-01T00:00:00.000Z", "card createdAt must survive the round trip");
+  assert.equal(warrior.updatedAt, "2024-04-02T00:00:00.000Z", "card updatedAt must survive the round trip");
 
   const expCol = cols.find(c => c.name === "Expansion");
   assert.equal(expCol.backLayoutId, tpl.id, "backLayoutId must survive the round trip");


### PR DESCRIPTION
## Summary

Items in lists — games, collections, cards and layouts — can now be labelled with **custom tags** and **sorted** by name, tag, created date or last modified date (ascending/descending, persisted per list).

### UI (`FilterableList`)

- **Sort control** in each list's subheader: Name / Tag / Created / Modified + direction toggle. The choice is persisted in localStorage per list. Options only appear when the list actually provides the data (e.g. Images only sorts by name). Items without a tag/date always sort last; ties fall back to natural name order.
- **Tag editor** for the selected item: a Tags button opens a chip row (× to remove, input with datalist suggestions from all existing tags in the list, Enter to add).
- **Tag badges** (`TagBadges`) shown next to item names in compact/detailed rows.
- Tags participate in the fuzzy filter, so typing a tag narrows the list.

### Data model & persistence

- `tags`, `createdAt`, `updatedAt` on `CardData`, `Collection` and `CardLayout`; `tags` on `GameMeta` (games already had timestamps).
- `normalize.ts` preserves the new fields (tags trimmed + deduped, empty → dropped).
- All four backends stamp collection timestamps on create/update and give card copies a fresh identity; an **explicit `updatedAt` in updates wins**, which lets zip import preserve history.
- UI saves stamp `updatedAt` through the mutation hooks (`useSaveCard`, `useSaveLayout`) and the editor's local save paths; card creation, collection cloning and CSV import stamp `createdAt`.
- `gameZip` restores collection tags/timestamps and game tags/`createdAt` after import, so tags and history survive cross-backend transfers.

### Tests

- `test/backendCompat.test.js`: `createFullTestGame`/`verifyFullTestGame` now set and assert tags + timestamps on the game, layout, collection and a card, confirming they survive localFile, indexedDB, S3 and cross-backend zip transfers.
- Full suite passes: **213/213**.
- Verified end-to-end in the browser (Playwright): tagging a game/card, badge rendering, tag/modified sorting, persistence across reload, and tag removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxxdQhje7v3sUkUdfbLE7a

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxxdQhje7v3sUkUdfbLE7a)_