### PR TITLE
Filter lists by selecting tags, with clickable badges

### DIFF
--- a/src/components/FilterableList.tsx
+++ b/src/components/FilterableList.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, createContext, useContext, type ReactNode } from 'react'
 import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight, TextCursorInput, Check, X, Tags, ArrowUpNarrowWide, ArrowDownWideNarrow, ListFilter } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -15,14 +15,30 @@ type SortState = { by: SortBy; dir: 'asc' | 'desc' }
 const DEFAULT_DIR: Record<SortBy, 'asc' | 'desc'> = { name: 'asc', tag: 'asc', created: 'desc', updated: 'desc' }
 const naturalCompare = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare
 
-/** Small pill badges for an item's tags — drop into any renderItem. */
+// Lets TagBadges (rendered by callers inside renderItem) reach the enclosing
+// list's tag filter without threading props through every renderItem.
+const TagFilterContext = createContext<{ toggle: (tag: string) => void; active: Set<string> } | null>(null)
+
+/** Small pill badges for an item's tags — drop into any renderItem.
+ * Inside a FilterableList with a tag filter, clicking a badge toggles that
+ * tag in the filter; elsewhere the badges render as plain pills. */
 export function TagBadges({ tags }: { tags?: string[] }) {
+  const filter = useContext(TagFilterContext)
   if (!tags?.length) return null
   return (
     <span className="inline-flex flex-wrap items-center gap-1">
-      {tags.map(t => (
-        <span key={t} className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] leading-none text-primary whitespace-nowrap">{t}</span>
-      ))}
+      {tags.map(t => {
+        const active = filter?.active.has(t)
+        const className = `rounded-full px-1.5 py-0.5 text-[10px] leading-none whitespace-nowrap ${active ? 'bg-primary text-primary-foreground' : 'bg-primary/10 text-primary'}`
+        if (!filter) return <span key={t} className={className}>{t}</span>
+        return (
+          <button key={t} type="button" className={`${className} hover:bg-primary/20 transition-colors ${active ? 'hover:bg-primary/80' : ''}`}
+            title={active ? `Stop filtering by "${t}"` : `Filter by "${t}"`}
+            onClick={(e) => { e.stopPropagation(); filter.toggle(t) }}>
+            {t}
+          </button>
+        )
+      })}
     </span>
   )
 }
@@ -370,7 +386,13 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
   // selected item hidden by the filter) fall back to the subheader.
   const renameInSubheader = renaming && !!selectedItem && (!!isGrid || !!showBigPreview || selectedIdx < 0)
 
-  return (<>
+  // Clicking a badge inside renderItem toggles that tag in the filter.
+  const tagFilterCtx = useMemo(
+    () => getTags ? { toggle: toggleFilterTag, active: tagFilter } : null,
+    [!!getTags, tagFilter]
+  )
+
+  return (<TagFilterContext.Provider value={tagFilterCtx}>
     {hoverThumb && (
       <div className="pointer-events-none fixed z-50" style={{ left: hoverThumb.x + 16, top: hoverThumb.y - 80, width: 120 }}>
         <CardThumbnail src={hoverThumb.src} name="" />
@@ -594,5 +616,5 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
         )}
       </>}
     </div>
-  </>)
+  </TagFilterContext.Provider>)
 }

--- a/src/components/FilterableList.tsx
+++ b/src/components/FilterableList.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from 'react'
-import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight, TextCursorInput, Check, X, Tags, ArrowUpNarrowWide, ArrowDownWideNarrow } from 'lucide-react'
+import { Minus, Plus, Eye, List, LayoutGrid, GalleryHorizontalEnd, ChevronLeft, ChevronRight, TextCursorInput, Check, X, Tags, ArrowUpNarrowWide, ArrowDownWideNarrow, ListFilter } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import useFuzzyFilter from '@/hooks/useFuzzyFilter'
@@ -94,10 +94,29 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
   // A persisted choice may reference accessors this list no longer provides.
   const sortBy: SortBy = sortOptions.some(o => o.value === sort.by) ? sort.by : 'name'
 
+  // ── Tag filter (select tags to narrow the list) ─────────────────
+  const [tagFilter, setTagFilter] = useState<Set<string>>(new Set())
+  const [tagFilterOpen, setTagFilterOpen] = useState(false)
+  const allTags = useMemo(
+    () => getTags ? [...new Set(items.flatMap(i => getTags(i) ?? []))].sort(naturalCompare) : [],
+    [items, getTags]
+  )
+  // Drop filter entries whose tag no longer exists anywhere (e.g. removed
+  // from its last item) so the list can't get stuck empty.
+  useEffect(() => {
+    setTagFilter(prev => {
+      if (![...prev].some(t => !allTags.includes(t))) return prev
+      return new Set([...prev].filter(t => allTags.includes(t)))
+    })
+  }, [allTags])
+
   const filtered = useMemo(() => {
     const dirMul = sort.dir === 'desc' ? -1 : 1
     const byName = (a: T, b: T) => naturalCompare(getName(a), getName(b))
-    const arr = [...matched]
+    // Selected filter tags narrow progressively: an item must carry them all.
+    const arr = tagFilter.size > 0
+      ? matched.filter(i => { const ts = getTags?.(i) ?? []; return [...tagFilter].every(t => ts.includes(t)) })
+      : [...matched]
     if (sortBy === 'name') return arr.sort((a, b) => dirMul * byName(a, b))
     const sortValue = (item: T): string | undefined => {
       if (sortBy === 'tag') {
@@ -115,7 +134,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
       const cmp = sortBy === 'tag' ? naturalCompare(va, vb) : (va < vb ? -1 : va > vb ? 1 : 0)
       return dirMul * cmp || byName(a, b)
     })
-  }, [matched, sortBy, sort.dir, getName, getTags, getCreatedAt, getUpdatedAt])
+  }, [matched, tagFilter, sortBy, sort.dir, getName, getTags, getCreatedAt, getUpdatedAt])
 
   // ── Tag editing (selected item) ─────────────────────────────────
   const [editingTags, setEditingTags] = useState(false)
@@ -123,10 +142,6 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
   // Custom suggestions dropdown — a native <datalist> renders nothing in
   // several browsers, so existing tags get a real, clickable list instead.
   const [tagSuggestionsOpen, setTagSuggestionsOpen] = useState(false)
-  const allTags = useMemo(
-    () => getTags ? [...new Set(items.flatMap(i => getTags(i) ?? []))].sort(naturalCompare) : [],
-    [items, getTags]
-  )
   const { collapsed, toggle } = useCollapsible()
   const containerRef = useRef<HTMLDivElement>(null)
   const itemRefs = useRef<Map<string, HTMLElement>>(new Map())
@@ -267,6 +282,48 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
     if (!tag || selectedTags.includes(tag)) return
     onTagsChange(getKey(selectedItem), [...selectedTags, tag])
   }
+  const toggleFilterTag = (tag: string) => {
+    setTagFilter(prev => {
+      const next = new Set(prev)
+      next.has(tag) ? next.delete(tag) : next.add(tag)
+      return next
+    })
+  }
+  const tagFilterControl = getTags && allTags.length > 0 ? (
+    <div className="relative" onClick={(e) => e.stopPropagation()}>
+      <button
+        className={`flex items-center gap-0.5 rounded p-1 transition-colors ${tagFilter.size > 0 || tagFilterOpen ? 'text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+        title="Filter by tags"
+        onClick={() => setTagFilterOpen(v => !v)}>
+        <ListFilter className="h-3.5 w-3.5" />
+        {tagFilter.size > 0 && <span className="text-[10px] leading-none">{tagFilter.size}</span>}
+      </button>
+      {tagFilterOpen && <>
+        <div className="fixed inset-0 z-10" onClick={() => setTagFilterOpen(false)} />
+        <div className="absolute left-0 top-full z-20 mt-1 max-h-48 w-44 overflow-y-auto rounded-md border bg-card py-1 shadow-md">
+          {allTags.map(tag => {
+            const active = tagFilter.has(tag)
+            return (
+              <button key={tag} type="button"
+                className="flex w-full items-center gap-2 px-2 py-1 text-left text-xs hover:bg-muted transition-colors"
+                onClick={() => toggleFilterTag(tag)}>
+                <Check className={`h-3 w-3 shrink-0 ${active ? 'text-primary' : 'text-transparent'}`} />
+                <span className={`truncate ${active ? 'text-primary font-medium' : ''}`}>{tag}</span>
+              </button>
+            )
+          })}
+          {tagFilter.size > 0 && (
+            <button type="button"
+              className="mt-1 flex w-full items-center gap-2 border-t px-2 py-1 pt-1.5 text-left text-xs text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setTagFilter(new Set())}>
+              <X className="h-3 w-3 shrink-0" />
+              Clear filter
+            </button>
+          )}
+        </div>
+      </>}
+    </div>
+  ) : null
   const sortControl = sortProp ? (
     <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
       <select
@@ -361,6 +418,7 @@ export default function FilterableList<T>({ title, items, getKey, getName, getPr
                 </label>
               )}
               {sortControl}
+              {tagFilterControl}
               {subheader && <div className="flex items-center gap-1 ml-2">{subheader}</div>}
               {isGrid && <>
                 <button className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-30" disabled={cols <= 1}


### PR DESCRIPTION
## Summary

Follow-up to #80/#81 — lists can now be filtered by selecting tags:

- **Tag filter control**: lists that carry tags get a filter button next to the sort control. It opens a dropdown of every existing tag; selecting tags narrows the list to items carrying **all** of them (progressive narrowing). The button shows a live count of active filter tags and the dropdown offers a "Clear filter" entry. Filter tags that disappear from every item are dropped automatically so the list can't get stuck empty.
- **Clickable tag badges**: clicking a badge on a list row toggles that tag in the filter. Active badges render filled, and a second click removes the tag from the filter. The filter state reaches `TagBadges` through a React context, so callers' `renderItem` implementations needed no changes.

## Testing

- `npm test`: 213/213 pass, `tsc` clean.
- Verified in the browser (Playwright): filter dropdown lists all tags; selecting "royal" narrows 54 cards to 2, adding "hearts" narrows to 1, "Clear filter" restores everything; clicking a row badge activates the filter (with the count shown on the button) and clicking the now-filled badge deactivates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxxdQhje7v3sUkUdfbLE7a

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxxdQhje7v3sUkUdfbLE7a)_