### PR TITLE
Add color-to-alpha tool to the image editor

### DIFF
--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -2,8 +2,10 @@ import { useState, useCallback, useEffect } from 'react'
 import Cropper from 'react-easy-crop'
 import { Button } from '@/components/ui/button'
 import { FloatingInput } from '@/components/ui/floating-field'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Slider } from '@/components/ui/slider'
 import { NumberEditor } from '@/components/layout/ControlPanel'
-import { X, Save, SaveAll, Link, Unlink } from 'lucide-react'
+import { X, Save, SaveAll, Link, Unlink, Pipette } from 'lucide-react'
 
 type Area = { x: number; y: number; width: number; height: number }
 
@@ -66,6 +68,49 @@ function createImage(url: string): Promise<HTMLImageElement> {
   })
 }
 
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '')
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]
+}
+
+// GIMP-style color-to-alpha: pixels matching the key color become transparent,
+// blends with the key color become semi-transparent with the key un-mixed from them.
+// transparency/opacity thresholds (0..1) bound the distance-to-alpha ramp.
+function applyColorToAlpha(data: Uint8ClampedArray, key: [number, number, number], transparency: number, opacity: number) {
+  const [kr, kg, kb] = key
+  const channelDist = (c: number, k: number) => (c > k ? (c - k) / (255 - k) : c < k ? (k - c) / k : 0)
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i], g = data[i + 1], b = data[i + 2]
+    const d = Math.max(channelDist(r, kr), channelDist(g, kg), channelDist(b, kb))
+    let a: number
+    if (d <= transparency) a = 0
+    else if (d >= opacity || opacity <= transparency) a = 1
+    else a = (d - transparency) / (opacity - transparency)
+    if (a === 1) continue
+    if (a === 0) {
+      data[i + 3] = 0
+      continue
+    }
+    data[i] = Math.min(255, Math.max(0, Math.round(kr + (r - kr) / a)))
+    data[i + 1] = Math.min(255, Math.max(0, Math.round(kg + (g - kg) / a)))
+    data[i + 2] = Math.min(255, Math.max(0, Math.round(kb + (b - kb) / a)))
+    data[i + 3] = Math.round(data[i + 3] * a)
+  }
+}
+
+async function colorToAlphaDataUrl(src: string, color: string, transparency: number, opacity: number): Promise<string> {
+  const image = await createImage(src)
+  const canvas = document.createElement('canvas')
+  canvas.width = image.width
+  canvas.height = image.height
+  const ctx = canvas.getContext('2d')!
+  ctx.drawImage(image, 0, 0)
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  applyColorToAlpha(imageData.data, hexToRgb(color), transparency, opacity)
+  ctx.putImageData(imageData, 0, 0)
+  return canvas.toDataURL('image/png')
+}
+
 function rotateSize(width: number, height: number, rotation: number) {
   const rotRad = (rotation * Math.PI) / 180
   return {
@@ -90,6 +135,40 @@ export default function ImageEditor({ src, aspectRatio, filename, onSave, onSave
   const [lockAspect, setLockAspect] = useState(true)
   const [outW, setOutW] = useState(0)
   const [outH, setOutH] = useState(0)
+  const [c2aEnabled, setC2aEnabled] = useState(false)
+  const [c2aColor, setC2aColor] = useState('#ffffff')
+  const [c2aTransparency, setC2aTransparency] = useState(0)
+  const [c2aOpacity, setC2aOpacity] = useState(1)
+  const [c2aSrc, setC2aSrc] = useState<string | null>(null)
+
+  // Recompute the color-to-alpha preview (debounced) when the key color or thresholds change
+  useEffect(() => {
+    if (!c2aEnabled) {
+      setC2aSrc(null)
+      return
+    }
+    let cancelled = false
+    const timer = setTimeout(() => {
+      colorToAlphaDataUrl(src, c2aColor, c2aTransparency, c2aOpacity)
+        .then(url => { if (!cancelled) setC2aSrc(url) })
+        .catch(() => {})
+    }, 150)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [src, c2aEnabled, c2aColor, c2aTransparency, c2aOpacity])
+
+  const effectiveSrc = (c2aEnabled && c2aSrc) || src
+
+  const pickColor = async () => {
+    const EyeDropperCtor = (window as unknown as { EyeDropper?: new () => { open: () => Promise<{ sRGBHex: string }> } }).EyeDropper
+    if (!EyeDropperCtor) return
+    try {
+      const result = await new EyeDropperCtor().open()
+      setC2aColor(result.sRGBHex)
+      setC2aEnabled(true)
+    } catch {
+      // picking cancelled
+    }
+  }
 
   // Initialize aspect and output size from image
   useEffect(() => {
@@ -121,7 +200,7 @@ export default function ImageEditor({ src, aspectRatio, filename, onSave, onSave
     if (!croppedAreaPixels) return null
     const ow = outW > 0 ? outW : undefined
     const oh = outH > 0 ? outH : undefined
-    return getCroppedImg(src, croppedAreaPixels, rotation, 'image/png', 1.0, ow, oh)
+    return getCroppedImg(effectiveSrc, croppedAreaPixels, rotation, 'image/png', 1.0, ow, oh)
   }
 
   const editedName = editName.trim() || undefined
@@ -151,7 +230,7 @@ export default function ImageEditor({ src, aspectRatio, filename, onSave, onSave
     <div className="space-y-3">
       <div className="relative w-full rounded-md border overflow-hidden" style={{ height: 300, backgroundImage: 'repeating-conic-gradient(#e5e5e5 0% 25%, transparent 0% 50%)', backgroundSize: '12px 12px' }}>
         <Cropper
-          image={src}
+          image={effectiveSrc}
           crop={crop}
           zoom={zoom}
           minZoom={0.1}
@@ -215,6 +294,47 @@ export default function ImageEditor({ src, aspectRatio, filename, onSave, onSave
             else if (!lockAspect && outW > 0) { const a = outW / h; setAspect(a) }
           }} min={1} max={9999} step={1} />
         </div>
+      </div>
+
+      <div className="space-y-2 rounded-md border p-2">
+        <div className="flex items-center gap-2">
+          <Checkbox id="color-to-alpha" checked={c2aEnabled} onCheckedChange={(v) => setC2aEnabled(v === true)} />
+          <label htmlFor="color-to-alpha" className="text-xs font-medium cursor-pointer select-none">Color to alpha</label>
+        </div>
+        {c2aEnabled && (
+          <>
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                value={c2aColor}
+                onChange={(e) => setC2aColor(e.target.value)}
+                className="h-7 w-9 cursor-pointer rounded border bg-transparent p-0.5"
+                title="Color to make transparent"
+              />
+              <span className="text-xs text-muted-foreground font-mono">{c2aColor}</span>
+              {'EyeDropper' in window && (
+                <button
+                  type="button"
+                  className="rounded p-1.5 text-muted-foreground hover:text-foreground transition-colors"
+                  title="Pick color from screen"
+                  onClick={pickColor}
+                >
+                  <Pipette className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Transparency threshold ({Math.round(c2aTransparency * 100)}%)</label>
+                <Slider value={[c2aTransparency]} onValueChange={([v]) => setC2aTransparency(v)} min={0} max={1} step={0.01} />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Opacity threshold ({Math.round(c2aOpacity * 100)}%)</label>
+                <Slider value={[c2aOpacity]} onValueChange={([v]) => setC2aOpacity(v)} min={0} max={1} step={0.01} />
+              </div>
+            </div>
+          </>
+        )}
       </div>
 
       <div className="flex gap-2 justify-end">

--- a/src/storage/localFile.js
+++ b/src/storage/localFile.js
@@ -248,7 +248,12 @@ export const createLocalFileStorage = ({ defaultLayout }) => {
     async uploadImage(gameId, file) {
       const response = await fetch(`${apiBase}/games/${gameId}/images/upload`, {
         method: "POST",
-        headers: { "Content-Disposition": `attachment; filename="${file.name}"` },
+        // Explicit Content-Type: the server's express.raw({ type: "*/*" }) skips
+        // bodies without one, leaving req.body undefined.
+        headers: {
+          "Content-Disposition": `attachment; filename="${file.name}"`,
+          "Content-Type": file.type || "application/octet-stream",
+        },
         body: await file.arrayBuffer(),
       });
       if (!response.ok) throw new Error("Failed to upload image");


### PR DESCRIPTION
## Summary

- Adds a **Color to alpha** section to the image editor (`ImageEditor.tsx`), GIMP-style: pixels matching the key color become fully transparent, and blends with the key color become semi-transparent with the key color un-mixed from them (so anti-aliased edges over a white background extract cleanly).
- Controls: enable checkbox, color swatch (native color input), an EyeDropper picker (shown when the browser supports the EyeDropper API), and two sliders — **Transparency threshold** (distances below → fully transparent, default 0%) and **Opacity threshold** (distances above → fully opaque, default 100%).
- The effect previews live in the cropper (debounced 150 ms) over the existing checkerboard background, and is baked into the saved PNG for both "Replace" and "Save as new".

## Bug fix

Image upload in the `localFile` storage backend always failed with a 500: `fetch` sends `ArrayBuffer` bodies without a `Content-Type` header, so the server's `express.raw({ type: "*/*" })` never parsed the body and `Buffer.from(req.body)` threw on `undefined`. The upload now sends an explicit `Content-Type`, which fixes saving from the image editor (and any other upload through this backend).

## Testing

- `npm test` — 213/213 pass.
- Verified end-to-end with Playwright: uploaded a red-circle-on-white test image, enabled color to alpha with the default white key, saved as new, and checked the saved PNG's pixels — background alpha 0, circle opaque, and the un-mixed color recomposites to the original over white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPApUTVBfUewjfwevE1YHV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPApUTVBfUewjfwevE1YHV)_