### PR TITLE
Add sort control to the gallery image picker

### DIFF
--- a/src/components/layout/ControlPanel.tsx
+++ b/src/components/layout/ControlPanel.tsx
@@ -313,6 +313,7 @@ function ImageGalleryPicker({ images, selected, onSelect }: { images: { file: st
       getKey={img => img.file}
       getName={img => img.name}
       grid={{ colsKey: 'pickerCols' }}
+      sort={{ key: 'pickerSort' }}
       maxHeight="12rem"
       selectedKey={images.find(i => i.url === selected)?.file}
       onSelect={(key) => { const img = images.find(i => i.file === key); if (img) onSelect(img.url) }}


### PR DESCRIPTION
## Summary

The "Pick from gallery" image picker (used by every image property editor) listed images in a fixed name-ascending order with no way to change it, while the Images gallery on the collections page already had a sort control. The picker's `FilterableList` now gets the `sort` prop, so it shows the same sort dropdown and ascending/descending toggle in its subheader. The choice is persisted under a global `pickerSort` localStorage key, mirroring the existing global `pickerCols` key used for the picker's column count.

About the filter: the fuzzy text filter was already present in the picker's header (top-right "Filter..." box) and verified working — typing narrows the grid. The gallery's tag filter doesn't apply here because images carry no tags (`ImageEntry` is `{ file, url, name }`).

## Testing

- `npx tsc --noEmit` clean
- `npm test`: 213/213 pass
- Verified in the running app with Playwright: the picker now shows the Name sort select + direction toggle, and flipping the direction reorders the thumbnails (A→Z / Z→A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Nd77ci9Hs3pjQLfptkit6

---
_Generated by [Claude Code](https://claude.ai/code/session_016Nd77ci9Hs3pjQLfptkit6)_